### PR TITLE
Support include statements

### DIFF
--- a/editor/nibble.vim
+++ b/editor/nibble.vim
@@ -10,7 +10,11 @@ endif
 syntax keyword nibbleTodos TODO NOTE IMPORTANT FIXME
 
 " Language keywords
-syntax keyword nibbleKeywords var const proc typedef sizeof typeof #static_assert export import from as label goto break continue return if else while do for switch case
+syntax keyword nibbleKeywords var const proc typedef sizeof typeof export import from as label goto break continue return if else while do for switch case
+
+syntax region nibbleIncluded start=/"/ skip=/\\\\\|\\"/ end=/"/  display contained
+syntax match nibbleInclude /^\s*\zs#include\>\s*"/ display contains=nibbleIncluded
+syntax match nibbleStatisAssert '\s*\zs#static_assert\>\s*'
 
 syntax keyword nibbleStructure struct union enum
 syntax keyword nibbleType void u8 s8 u16 s16 u32 s32 u64 s64 f32 f64 bool char schar uchar short ushort int uint long ulong llong ullong ssize usize
@@ -26,7 +30,9 @@ syntax region nibbleString start=/\v'/ skip=/\v\\./ end=/\v'/
 
 " Set highlights
 highlight default link nibbleTodos Todo
-highlight default link nibbleKeywords Keyword
+highlight default link nibbleKeywords Include
+highlight default link nibbleStatisAssert Keyword
+highlight default link nibbleInclude Keyword
 highlight default link nibbleStructure Structure
 highlight default link nibbleType Type
 highlight default link nibbleBoolean Boolean

--- a/src/ast.c
+++ b/src/ast.c
@@ -392,8 +392,8 @@ PortSymbol* new_port_symbol(Allocator* allocator, Identifier* name, Identifier* 
     return psym;
 }
 
-Stmt* new_stmt_import(Allocator* allocator, size_t num_imports, List* import_syms, StrLit* mod_pathname, Identifier* mod_namespace,
-                      ProgRange range)
+Stmt* new_stmt_import(Allocator* allocator, size_t num_imports, List* import_syms, StrLit* mod_pathname,
+                      Identifier* mod_namespace, ProgRange range)
 {
     StmtImport* stmt = new_stmt(allocator, StmtImport, range);
     stmt->mod_pathname = mod_pathname;
@@ -1053,10 +1053,10 @@ char* symbol_mangled_name(Allocator* allocator, Symbol* sym)
         ftprint_char_array(&dstr, true, "%s_%s", intrin_pre, sym->name->str);
     }
     else if (!sym->is_local) {
-        len += sym->home->mod_path->len + 1;
+        len += sym->home->cpath_lit->len + 1;
         dstr = array_create(allocator, char, len + 1);
 
-        ftprint_char_array(&dstr, true, "%s_%s", sym->home->mod_path->str, sym->name->str);
+        ftprint_char_array(&dstr, true, "%s_%s", sym->home->cpath_lit->str, sym->name->str);
     }
     else {
         dstr = array_create(allocator, char, len + 1);
@@ -1159,14 +1159,15 @@ bool install_module_decls(Allocator* allocator, Module* mod)
             Symbol* sym = add_unresolved_symbol(allocator, mod_scope, mod, decl);
 
             if (!sym) {
-                report_error(mod->mod_path->str, decl->range, "Duplicate definition of symbol `%s`", decl->name->str);
+                report_error(mod->cpath_lit->str, decl->range, "Duplicate definition of symbol `%s`", decl->name->str);
                 return false;
             }
 
             // Add to export table if decl is exported.
             if (decl->flags & DECL_IS_EXPORTED) {
                 if (!module_add_export_sym(mod, sym->name, sym)) {
-                    report_error(mod->mod_path->str, decl->range, "Conflicting export symbol name `%s`", sym->name->str);
+                    report_error(mod->cpath_lit->str, decl->range, "Conflicting export symbol name `%s`",
+                                 sym->name->str);
                     return false;
                 }
             }
@@ -1195,11 +1196,11 @@ bool module_add_global_sym(Module* mod, Identifier* name, Symbol* sym)
 
         if (sym->home == mod) {
             // TODO: Module path is NOT the file's OS path. FIXME
-            report_error(mod->mod_path->str, range, "Duplicate definition of symbol `%s`", name->str);
+            report_error(mod->cpath_lit->str, range, "Duplicate definition of symbol `%s`", name->str);
         }
         else {
             // TODO: Module path is NOT the file's OS path. FIXME
-            report_error(mod->mod_path->str, range, "Conflicting import name `%s`", name->str);
+            report_error(mod->cpath_lit->str, range, "Conflicting import name `%s`", name->str);
         }
 
         return false;
@@ -1243,8 +1244,9 @@ bool import_mod_syms(Module* dst_mod, Module* src_mod, StmtImport* stmt)
         Symbol* sym = module_get_export_sym(src_mod, isym->name);
 
         if (!sym) {
-            report_error(dst_mod->mod_path->str, stmt->super.range, "Importing unknown or private symbol `%s` from module `%s`",
-                         isym->name->str, src_mod->mod_path->str); // TODO: mod_path is not an OS path
+            report_error(dst_mod->cpath_lit->str, stmt->super.range,
+                         "Importing unknown or private symbol `%s` from module `%s`", isym->name->str,
+                         src_mod->cpath_lit->str); // TODO: mod_path is not an OS path
             return false;
         }
 
@@ -1260,9 +1262,9 @@ bool import_mod_syms(Module* dst_mod, Module* src_mod, StmtImport* stmt)
     return true;
 }
 
-void module_init(Module* mod, StrLit* mod_path)
+void module_init(Module* mod, StrLit* cpath_lit)
 {
-    mod->mod_path = mod_path;
+    mod->cpath_lit = cpath_lit;
     mod->num_decls = 0;
 
     memset(&mod->export_table, 0, sizeof(HMap));

--- a/src/ast.c
+++ b/src/ast.c
@@ -415,6 +415,14 @@ Stmt* new_stmt_export(Allocator* allocator, size_t num_exports, List* export_sym
     return (Stmt*)stmt;
 }
 
+Stmt* new_stmt_include(Allocator* allocator, StrLit* file_pathname, ProgRange range)
+{
+    StmtInclude* stmt = new_stmt(allocator, StmtInclude, range);
+    stmt->file_pathname = file_pathname;
+
+    return (Stmt*)stmt;
+}
+
 Identifier* get_import_sym_name(StmtImport* stmt, Identifier* name)
 {
     //
@@ -1776,9 +1784,15 @@ char* ftprint_stmt(Allocator* allocator, Stmt* stmt)
                 ftprint_char_array(&dstr, false, ")");
             }
         } break;
+        case CST_StmtInclude: {
+            StmtInclude* s = (StmtInclude*)stmt;
+            dstr = array_create(allocator, char, 32);
+
+            ftprint_char_array(&dstr, false, "(include \"%s\")", s->file_pathname->str);
+        } break;
         case CST_StmtImport: {
             StmtImport* s = (StmtImport*)stmt;
-            dstr = array_create(allocator, char, 16);
+            dstr = array_create(allocator, char, 32);
 
             ftprint_char_array(&dstr, false, "(import ");
 
@@ -1810,7 +1824,7 @@ char* ftprint_stmt(Allocator* allocator, Stmt* stmt)
         } break;
         case CST_StmtExport: {
             StmtExport* s = (StmtExport*)stmt;
-            dstr = array_create(allocator, char, 16);
+            dstr = array_create(allocator, char, 32);
 
             ftprint_char_array(&dstr, false, "(export ");
 

--- a/src/ast.h
+++ b/src/ast.h
@@ -828,7 +828,7 @@ bool import_all_mod_syms(Module* dst_mod, Module* src_mod);
 ///////////////////////////////
 
 struct Module {
-    StrLit* mod_path;
+    StrLit* cpath_lit;
     List import_stmts;
     List export_stmts;
     List stmts;
@@ -841,7 +841,7 @@ struct Module {
     size_t num_exports;
 };
 
-void module_init(Module* mod, StrLit* mod_path);
+void module_init(Module* mod, StrLit* cpath_lit);
 void module_init_tables(Module* mod, Allocator* allocator, size_t num_builtins);
 Symbol* module_get_export_sym(Module* mod, Identifier* name);
 bool module_add_export_sym(Module* mod, Identifier* name, Symbol* sym);

--- a/src/ast.h
+++ b/src/ast.h
@@ -296,6 +296,7 @@ typedef enum StmtKind {
     CST_StmtStaticAssert,
     CST_StmtExport,
     CST_StmtImport,
+    CST_StmtInclude,
 } StmtKind;
 
 struct Stmt {
@@ -331,6 +332,11 @@ typedef struct StmtExport {
     List export_syms;
     size_t num_exports;
 } StmtExport;
+
+typedef struct StmtInclude {
+    Stmt super;
+    StrLit* file_pathname;
+} StmtInclude;
 
 typedef struct StmtNoOp {
     Stmt super;
@@ -461,6 +467,7 @@ PortSymbol* new_port_symbol(Allocator* allocator, Identifier* name, Identifier* 
 Stmt* new_stmt_import(Allocator* allocator, size_t num_imports, List* import_syms, StrLit* mod_pathname, Identifier* mod_namespace,
                       ProgRange range);
 Stmt* new_stmt_export(Allocator* allocator, size_t num_exports, List* export_syms, ProgRange range);
+Stmt* new_stmt_include(Allocator* allocator, StrLit* file_pathname, ProgRange range);
 
 char* ftprint_stmt(Allocator* allocator, Stmt* stmt);
 Identifier* get_import_sym_name(StmtImport* stmt, Identifier* name);

--- a/src/nibble.c
+++ b/src/nibble.c
@@ -143,15 +143,12 @@ proc #writeout(buf: ^char, size: usize) => ssize;
 proc #readin(buf: ^char, size: usize) => ssize;
 */
 static const char builtin_code[] = {
-  0x70, 0x72, 0x6f, 0x63, 0x20, 0x23, 0x77, 0x72, 0x69, 0x74, 0x65, 0x6f,
-  0x75, 0x74, 0x28, 0x62, 0x75, 0x66, 0x3a, 0x20, 0x5e, 0x63, 0x68, 0x61,
-  0x72, 0x2c, 0x20, 0x73, 0x69, 0x7a, 0x65, 0x3a, 0x20, 0x75, 0x73, 0x69,
-  0x7a, 0x65, 0x29, 0x20, 0x3d, 0x3e, 0x20, 0x73, 0x73, 0x69, 0x7a, 0x65,
-  0x3b, 0x0a, 0x70, 0x72, 0x6f, 0x63, 0x20, 0x23, 0x72, 0x65, 0x61, 0x64,
-  0x69, 0x6e, 0x28, 0x62, 0x75, 0x66, 0x3a, 0x20, 0x5e, 0x63, 0x68, 0x61,
-  0x72, 0x2c, 0x20, 0x73, 0x69, 0x7a, 0x65, 0x3a, 0x20, 0x75, 0x73, 0x69,
-  0x7a, 0x65, 0x29, 0x20, 0x3d, 0x3e, 0x20, 0x73, 0x73, 0x69, 0x7a, 0x65,
-  0x3b, 0x0a, 0x00};
+    0x70, 0x72, 0x6f, 0x63, 0x20, 0x23, 0x77, 0x72, 0x69, 0x74, 0x65, 0x6f, 0x75, 0x74, 0x28, 0x62, 0x75,
+    0x66, 0x3a, 0x20, 0x5e, 0x63, 0x68, 0x61, 0x72, 0x2c, 0x20, 0x73, 0x69, 0x7a, 0x65, 0x3a, 0x20, 0x75,
+    0x73, 0x69, 0x7a, 0x65, 0x29, 0x20, 0x3d, 0x3e, 0x20, 0x73, 0x73, 0x69, 0x7a, 0x65, 0x3b, 0x0a, 0x70,
+    0x72, 0x6f, 0x63, 0x20, 0x23, 0x72, 0x65, 0x61, 0x64, 0x69, 0x6e, 0x28, 0x62, 0x75, 0x66, 0x3a, 0x20,
+    0x5e, 0x63, 0x68, 0x61, 0x72, 0x2c, 0x20, 0x73, 0x69, 0x7a, 0x65, 0x3a, 0x20, 0x75, 0x73, 0x69, 0x7a,
+    0x65, 0x29, 0x20, 0x3d, 0x3e, 0x20, 0x73, 0x73, 0x69, 0x7a, 0x65, 0x3b, 0x0a, 0x00};
 
 static bool init_intrinsics()
 {
@@ -180,19 +177,33 @@ static bool init_intrinsics()
 static bool init_keywords()
 {
     static const StringView names[KW_COUNT] = {
-        [KW_VAR] = string_view_lit("var"),         [KW_CONST] = string_view_lit("const"),
-        [KW_ENUM] = string_view_lit("enum"),       [KW_UNION] = string_view_lit("union"),
-        [KW_STRUCT] = string_view_lit("struct"),   [KW_PROC] = string_view_lit("proc"),
-        [KW_TYPEDEF] = string_view_lit("typedef"), [KW_SIZEOF] = string_view_lit("#sizeof"),
-        [KW_TYPEOF] = string_view_lit("#typeof"),  [KW_STATIC_ASSERT] = string_view_lit("#static_assert"),
-        [KW_EXPORT] = string_view_lit("export"),   [KW_IMPORT] = string_view_lit("import"),
-        [KW_FROM] = string_view_lit("from"),       [KW_AS] = string_view_lit("as"),
-        [KW_LABEL] = string_view_lit("label"),     [KW_GOTO] = string_view_lit("goto"),
-        [KW_BREAK] = string_view_lit("break"),     [KW_CONTINUE] = string_view_lit("continue"),
-        [KW_RETURN] = string_view_lit("return"),   [KW_IF] = string_view_lit("if"),
-        [KW_ELSE] = string_view_lit("else"),       [KW_WHILE] = string_view_lit("while"),
-        [KW_DO] = string_view_lit("do"),           [KW_FOR] = string_view_lit("for"),
-        [KW_SWITCH] = string_view_lit("switch"),   [KW_CASE] = string_view_lit("case"),
+        [KW_VAR] = string_view_lit("var"),
+        [KW_CONST] = string_view_lit("const"),
+        [KW_ENUM] = string_view_lit("enum"),
+        [KW_UNION] = string_view_lit("union"),
+        [KW_STRUCT] = string_view_lit("struct"),
+        [KW_PROC] = string_view_lit("proc"),
+        [KW_TYPEDEF] = string_view_lit("typedef"),
+        [KW_SIZEOF] = string_view_lit("#sizeof"),
+        [KW_TYPEOF] = string_view_lit("#typeof"),
+        [KW_STATIC_ASSERT] = string_view_lit("#static_assert"),
+        [KW_EXPORT] = string_view_lit("export"),
+        [KW_IMPORT] = string_view_lit("import"),
+        [KW_FROM] = string_view_lit("from"),
+        [KW_AS] = string_view_lit("as"),
+        [KW_INCLUDE] = string_view_lit("#include"),
+        [KW_LABEL] = string_view_lit("label"),
+        [KW_GOTO] = string_view_lit("goto"),
+        [KW_BREAK] = string_view_lit("break"),
+        [KW_CONTINUE] = string_view_lit("continue"),
+        [KW_RETURN] = string_view_lit("return"),
+        [KW_IF] = string_view_lit("if"),
+        [KW_ELSE] = string_view_lit("else"),
+        [KW_WHILE] = string_view_lit("while"),
+        [KW_DO] = string_view_lit("do"),
+        [KW_FOR] = string_view_lit("for"),
+        [KW_SWITCH] = string_view_lit("switch"),
+        [KW_CASE] = string_view_lit("case"),
         [KW_UNDERSCORE] = string_view_lit("_"),
     };
 
@@ -306,11 +317,82 @@ static void init_builtin_syms(NibbleCtx* ctx)
     }
 }
 
-static bool parse_code(Module* mod, const char* code)
+typedef enum NibblePathErr {
+    NIB_PATH_OK = 0,
+    NIB_PATH_INV_PATH,
+    NIB_PATH_INV_EXT,
+    NIB_PATH_OUTSIDE_ROOT,
+} NibblePathErr;
+
+static NibblePathErr module_get_import_ospath(Path* import_ospath, const StrLit* import_path_str, const Path* base_ospath,
+                                                Path* mod_ospath, Allocator* alloc)
+{
+    path_init(import_ospath, alloc);
+
+    Path import_rel_path;
+    path_init(&import_rel_path, alloc);
+    path_set(&import_rel_path, import_path_str->str, import_path_str->len);
+
+    bool starts_root = import_path_str->str[0] == NIBBLE_PATH_SEP;
+
+    if (starts_root) {
+        path_set(import_ospath, base_ospath->str, base_ospath->len);
+    }
+    else {
+        const char* dir_begp = mod_ospath->str;
+        const char* dir_endp = path_filename(mod_ospath) - 1;
+
+        path_set(import_ospath, dir_begp, dir_endp - dir_begp);
+    }
+
+    path_join(import_ospath, &import_rel_path);
+
+    // Check if file's path exists somewhere.
+    if (!path_abs(import_ospath)) {
+        return NIB_PATH_INV_PATH;
+    }
+
+    // Check for .nib extension.
+    if (cstr_cmp(path_ext(import_ospath), nib_ext) != 0) {
+        return NIB_PATH_INV_EXT;
+    }
+
+    return NIB_PATH_OK;
+}
+
+static NibblePathErr canonicalize_ospath(Path* dst_path, const Path* src_ospath, const Path* base_ospath, Allocator* alloc)
+{
+    // TODO: Does not handle case where base_ospath is literally `/`.
+    assert(base_ospath->len > 1);
+
+    // Try to create a canonical module path (where `/` corresponds to main's home directory).
+    path_init(dst_path, alloc);
+
+    const char* bp = base_ospath->str;
+    const char* sp = src_ospath->str;
+
+    while (*bp && *sp && (*bp == *sp)) {
+        bp += 1;
+        sp += 1;
+    }
+
+    if (*bp) {
+        return NIB_PATH_OUTSIDE_ROOT;
+    }
+
+    assert(*sp == OS_PATH_SEP);
+
+    path_set(dst_path, sp, (src_ospath->str + src_ospath->len) - sp);
+    path_norm(dst_path, OS_PATH_SEP, NIBBLE_PATH_SEP);
+
+    return NIB_PATH_OK;
+}
+
+static bool parse_code(NibbleCtx* ctx, Module* mod, const char* code)
 {
     Parser parser = {0};
 
-    parser_init(&parser, &nibble->ast_mem, &nibble->tmp_mem, code, 0, &nibble->errors);
+    parser_init(&parser, &ctx->ast_mem, &ctx->tmp_mem, code, 0, &ctx->errors);
     next_token(&parser);
 
     while (!is_token_kind(&parser, TKN_EOF)) {
@@ -319,7 +401,50 @@ static bool parse_code(Module* mod, const char* code)
         if (!stmt || nibble->errors.count)
             return false;
 
-        if (stmt->kind == CST_StmtImport) {
+        if (stmt->kind == CST_StmtInclude) {
+            StmtInclude* stmt_include = (StmtInclude*)stmt;
+
+            Path mod_ospath;
+            module_get_ospath(&ctx->tmp_mem, &mod_ospath, mod, &ctx->base_ospath);
+
+            Path include_ospath;
+            NibblePathErr ret = module_get_import_ospath(&include_ospath, stmt_include->file_pathname, &ctx->base_ospath,
+                                                           &mod_ospath, &ctx->tmp_mem);
+
+            // Check if included file's path exists somewhere.
+            if (ret == NIB_PATH_INV_PATH) {
+                report_error(mod_ospath.str, stmt->range, "Invalid include path \"%s\"", stmt_include->file_pathname->str);
+                return false;
+            }
+
+            // Check for .nib extension.
+            if (ret == NIB_PATH_INV_EXT) {
+                report_error(mod_ospath.str, stmt->range, "Included file \"%s\" does not end in `.%s`",
+                             stmt_include->file_pathname->str, nib_ext);
+                return false;
+            }
+
+            assert(ret == NIB_PATH_OK);
+            Path include_canon_path;
+            ret = canonicalize_ospath(&include_canon_path, &include_ospath, &ctx->base_ospath, &ctx->tmp_mem);
+
+            // Check that include path is inside the project's root directory.
+            if (ret == NIB_PATH_OUTSIDE_ROOT) {
+                report_error(mod_ospath.str, stmt->range,
+                             "Relative include path \"%s\" is outside of project root dir \"%s\"",
+                             stmt_include->file_pathname->str, ctx->base_ospath.str);
+                return false;
+            }
+
+            assert(ret == NIB_PATH_OK);
+
+            const char* included_code = slurp_file(&ctx->tmp_mem, include_ospath.str);
+
+            if (!parse_code(ctx, mod, included_code)) {
+                return false;
+            }
+        }
+        else if (stmt->kind == CST_StmtImport) {
             StmtImport* stmt_import = (StmtImport*)stmt;
 
             // NOTE: A namespaced import only really imports one new symbol into a module.
@@ -340,14 +465,15 @@ static bool parse_code(Module* mod, const char* code)
                 StmtDecl* stmt_decl = (StmtDecl*)stmt;
 
                 mod->num_decls += 1;
-                if (stmt_decl->decl->flags & DECL_IS_EXPORTED) mod->num_exports += 1;
+                if (stmt_decl->decl->flags & DECL_IS_EXPORTED)
+                    mod->num_exports += 1;
             }
 
             list_add_last(&mod->stmts, &stmt->lnode);
         }
 
 #ifdef NIBBLE_PRINT_DECLS
-        ftprint_out("%s\n", ftprint_stmt(&nibble->gen_mem, stmt));
+        ftprint_out("%s\n", ftprint_stmt(&ctx->gen_mem, stmt));
 #endif
     }
 
@@ -412,7 +538,7 @@ static bool parse_module(NibbleCtx* ctx, Module* mod)
 
     code = slurp_file(&ctx->tmp_mem, mod_ospath.str);
 
-    if (!parse_code(mod, code)) {
+    if (!parse_code(ctx, mod, code)) {
         return false;
     }
 
@@ -453,68 +579,37 @@ static bool parse_module(NibbleCtx* ctx, Module* mod)
             // 2. If it exists, subtract base_ospath to generate the canonical module path.
 
             Path import_mod_ospath;
-            path_init(&import_mod_ospath, &ctx->tmp_mem);
-
-            Path import_rel_path;
-            path_init(&import_rel_path, &ctx->tmp_mem);
-            path_set(&import_rel_path, simport->mod_pathname->str, simport->mod_pathname->len);
-
-            bool starts_root = simport->mod_pathname->str[0] == NIBBLE_PATH_SEP;
-
-            if (starts_root) {
-                path_set(&import_mod_ospath, ctx->base_ospath.str, ctx->base_ospath.len);
-            }
-            else {
-                const char* dir_begp = mod_ospath.str;
-                const char* dir_endp = path_filename(&mod_ospath) - 1;
-
-                path_set(&import_mod_ospath, dir_begp, dir_endp - dir_begp);
-            }
-
-            path_join(&import_mod_ospath, &import_rel_path);
-
+            NibblePathErr ret_err = module_get_import_ospath(&import_mod_ospath, simport->mod_pathname, &ctx->base_ospath,
+                                                               &mod_ospath, &ctx->tmp_mem);
             // Check if imported module's path exists somewhere.
-            if (!path_abs(&import_mod_ospath)) {
+            if (ret_err == NIB_PATH_INV_PATH) {
                 report_error(mod_ospath.str, stmt->range, "Invalid module import path \"%s\"",
                              simport->mod_pathname->str);
                 return false;
             }
 
             // Check for .nib extension.
-            if (cstr_cmp(path_ext(&import_mod_ospath), nib_ext) != 0) {
-                report_error(mod_ospath.str, stmt->range, "Imported file \"%s\" does not end in `.%s`",
+            if (ret_err == NIB_PATH_INV_EXT) {
+                report_error(mod_ospath.str, stmt->range, "Imported module file \"%s\" does not end in `.%s`",
                              simport->mod_pathname->str, nib_ext);
                 return false;
             }
 
+            assert(ret_err == NIB_PATH_OK);
+
             // Try to create a canonical module path (where `/` corresponds to main's home directory).
             Path import_mod_path;
-            path_init(&import_mod_path, &ctx->tmp_mem);
+            ret_err = canonicalize_ospath(&import_mod_path, &import_mod_ospath, &ctx->base_ospath, &ctx->tmp_mem);
 
-            {
-                // NOTE: Does not handle case where base_ospath is literally `/`.
-                assert(ctx->base_ospath.len);
-
-                const char* bp = ctx->base_ospath.str;
-                const char* mp = import_mod_ospath.str;
-
-                while (*bp && *mp && (*bp == *mp)) {
-                    bp += 1;
-                    mp += 1;
-                }
-
-                if (*bp) {
-                    report_error(mod_ospath.str, stmt->range,
-                                 "Relative module import path \"%s\" is outside of project root dir \"%s\"",
-                                 simport->mod_pathname->str, ctx->base_ospath.str);
-                    return false;
-                }
-
-                assert(*mp == OS_PATH_SEP);
-
-                path_set(&import_mod_path, mp, (import_mod_ospath.str + import_mod_ospath.len) - mp);
-                path_norm(&import_mod_path, OS_PATH_SEP, NIBBLE_PATH_SEP);
+            // Check that import module path is inside the project's root directory.
+            if (ret_err == NIB_PATH_OUTSIDE_ROOT) {
+                report_error(mod_ospath.str, stmt->range,
+                             "Relative module import path \"%s\" is outside of project root dir \"%s\"",
+                             simport->mod_pathname->str, ctx->base_ospath.str);
+                return false;
             }
+
+            assert(ret_err == NIB_PATH_OK);
 
             //
             // Parse import module
@@ -569,22 +664,19 @@ static bool parse_module(NibbleCtx* ctx, Module* mod)
                 Symbol* sym = lookup_scope_symbol(&mod->scope, esym->name);
 
                 if (!sym) {
-                    report_error(mod_ospath.str, esym->range,
-                                 "Unknown export symbol `%s`", esym->name->str);
+                    report_error(mod_ospath.str, esym->range, "Unknown export symbol `%s`", esym->name->str);
                     return false;
                 }
 
                 // Prevent users from exporting builtin symbols.
                 if (sym->home == &ctx->builtin_mod) {
-                    report_error(mod_ospath.str, esym->range,
-                                 "Cannot export builtin symbol `%s`", esym->name->str);
+                    report_error(mod_ospath.str, esym->range, "Cannot export builtin symbol `%s`", esym->name->str);
                     return false;
                 }
 
                 // Add symbol to the module's export table
                 if (!module_add_export_sym(mod, esym->rename ? esym->rename : esym->name, sym)) {
-                    report_error(mod_ospath.str, esym->range,
-                                 "Conflicting export symbol name `%s`", esym->name->str);
+                    report_error(mod_ospath.str, esym->range, "Conflicting export symbol name `%s`", esym->name->str);
                     return false;
                 }
             }
@@ -658,7 +750,7 @@ void nibble_compile(const char* main_file, const char* output_file)
     ftprint_out("[INFO]: Parsing builtin module\n");
 
     const size_t num_builtin_types = ARRAY_LEN(builtin_types);
-    bool parse_ok = parse_code(builtin_mod, builtin_code);
+    bool parse_ok = parse_code(nibble, builtin_mod, builtin_code);
 
     if (!parse_ok) {
         ftprint_err("[ERROR]: Failed to parse builtin code\n");

--- a/src/nibble.h
+++ b/src/nibble.h
@@ -123,6 +123,7 @@ typedef enum Keyword {
     KW_IMPORT,
     KW_FROM,
     KW_AS,
+    KW_INCLUDE,
     KW_LABEL,
     KW_GOTO,
     KW_BREAK,

--- a/tests/import_all.nib
+++ b/tests/import_all.nib
@@ -1,7 +1,8 @@
 import "./cstring.nib";
 //import "/cstring.nib"; // Should also work
-//import "../src/main.c"; // Should fail: outside of project root dir
-//import "./main.c"; // Should fail: not a .nib file
+//import "../src/main.c"; // Should fail: Invalid ext
+//import "./main.c"; // Should fail: Does not exist
+//import "../tests/simple.nib"; // Fails: outside of project root dir
 
 proc main(argc : int, argv : ^^char) => int
 {

--- a/tests/include_test.nib
+++ b/tests/include_test.nib
@@ -1,0 +1,16 @@
+#include "./included_utils.nib";
+//#include "/included_utils.nib"; // Should also work
+//#include "../src/main.c"; // Should fail: Invalid ext
+//#include "./main.c"; // Should fail: Does not exist
+//#include "../tests/simple.nib"; // Fails: outside of project root dir
+
+proc main(argc : int, argv : ^^char) => int
+{
+    var a : ^char = "Hello\n";
+    var num_chars := len(a);
+
+    #writeout(a, num_chars);
+
+    return num_chars + UTILS_CONST + utils_var;
+}
+

--- a/tests/included_utils.nib
+++ b/tests/included_utils.nib
@@ -1,0 +1,21 @@
+
+proc len(s : ^char) => usize
+{
+    if (!s) {
+        return 0;
+    }
+
+    var count : usize = 0;
+
+    while (*s) {
+        s = s + 1;
+        count = count + 1;
+    }
+
+    return count;
+}
+
+const UTILS_CONST : int = 20;
+
+var utils_var : char = 100;
+


### PR DESCRIPTION


## Syntax and semantics
Adds simple `#include` statements to the language. These are meant to be used within modules to just copy/paste one file into another. This is similar to C's `include`. However, because nibble has order-independent declarations, the location of the include statement within the file doesn't matter.

**internal.nib**
```c
proc foo() => {
   // ...
}
```
**main.nib**
```c
#include "./internal.nib"; // Acts as if the file's contents appeared inline.

proc main() => int {
    foo();
    return 0;
}
```

TODO: Abort infinite #include chains.