### PR TITLE
Support more global variable declarations w/ initialization (nested arrays, pointers)

### DIFF
--- a/src/ast.c
+++ b/src/ast.c
@@ -233,8 +233,7 @@ MemberInitializer* new_member_initializer(Allocator* allocator, Expr* init, Desi
     return initzer;
 }
 
-Expr* new_expr_compound_lit(Allocator* allocator, TypeSpec* typespec, size_t num_initzers, List* initzers,
-                            ProgRange range)
+Expr* new_expr_compound_lit(Allocator* allocator, TypeSpec* typespec, size_t num_initzers, List* initzers, ProgRange range)
 {
     ExprCompoundLit* expr = new_expr(allocator, ExprCompoundLit, range);
     expr->typespec = typespec;
@@ -255,8 +254,7 @@ DeclAnnotation* new_annotation(Allocator* allocator, Identifier* ident, ProgRang
 }
 
 #define new_decl(a, k, n, r) (k*)new_decl_((a), sizeof(k), alignof(k), CST_##k, (n), (r))
-static Decl* new_decl_(Allocator* allocator, size_t size, size_t align, DeclKind kind, Identifier* name,
-                       ProgRange range)
+static Decl* new_decl_(Allocator* allocator, size_t size, size_t align, DeclKind kind, Identifier* name, ProgRange range)
 {
     Decl* decl = mem_allocate(allocator, size, align, true);
     decl->kind = kind;
@@ -343,8 +341,8 @@ AggregateField* new_aggregate_field(Allocator* allocator, Identifier* name, Type
     return field;
 }
 
-Decl* new_decl_proc(Allocator* allocator, Identifier* name, u32 num_params, List* params, TypeSpec* ret, List* stmts,
-                    u32 num_decls, bool is_incomplete, ProgRange range)
+Decl* new_decl_proc(Allocator* allocator, Identifier* name, u32 num_params, List* params, TypeSpec* ret, List* stmts, u32 num_decls,
+                    bool is_incomplete, ProgRange range)
 {
     DeclProc* decl = new_decl(allocator, DeclProc, name, range);
     decl->ret = ret;
@@ -394,8 +392,8 @@ PortSymbol* new_port_symbol(Allocator* allocator, Identifier* name, Identifier* 
     return psym;
 }
 
-Stmt* new_stmt_import(Allocator* allocator, size_t num_imports, List* import_syms, StrLit* mod_pathname,
-                      Identifier* mod_namespace, ProgRange range)
+Stmt* new_stmt_import(Allocator* allocator, size_t num_imports, List* import_syms, StrLit* mod_pathname, Identifier* mod_namespace,
+                      ProgRange range)
 {
     StmtImport* stmt = new_stmt(allocator, StmtImport, range);
     stmt->mod_pathname = mod_pathname;
@@ -644,9 +642,8 @@ int type_integer_ranks[] = {
 };
 
 static const char* type_names[] = {
-    [TYPE_VOID] = "void",     [TYPE_INTEGER] = "_integer_", [TYPE_FLOAT] = "_float_",
-    [TYPE_ENUM] = "_enum_",   [TYPE_PTR] = "_ptr_",         [TYPE_PROC] = "_proc_",
-    [TYPE_ARRAY] = "_array_", [TYPE_STRUCT] = "_struct_",   [TYPE_UNION] = "_union_",
+    [TYPE_VOID] = "void",   [TYPE_INTEGER] = "_integer_", [TYPE_FLOAT] = "_float_",   [TYPE_ENUM] = "_enum_",   [TYPE_PTR] = "_ptr_",
+    [TYPE_PROC] = "_proc_", [TYPE_ARRAY] = "_array_",     [TYPE_STRUCT] = "_struct_", [TYPE_UNION] = "_union_",
 };
 
 static const char* type_integer_names[] = {
@@ -722,7 +719,6 @@ bool type_has_incomplete_array(Type* type)
 
     while (t->kind == TYPE_ARRAY || t->kind == TYPE_PTR) {
         if (t->kind == TYPE_ARRAY) {
-
             if (t->as_array.len == 0) {
                 return true;
             }
@@ -982,18 +978,12 @@ void init_builtin_types(OS target_os, Arch target_arch, Allocator* ast_mem, Type
     bool invalid_os_arch = false;
 
     builtin_types[BUILTIN_TYPE_VOID] = (BuiltinType){.name = "void", .type = type_alloc(ast_mem, TYPE_VOID)};
-    builtin_types[BUILTIN_TYPE_U8] =
-        (BuiltinType){.name = "u8", .type = type_int_alloc(ast_mem, INTEGER_U8, 1, false, 0xFF)};
-    builtin_types[BUILTIN_TYPE_S8] =
-        (BuiltinType){.name = "s8", .type = type_int_alloc(ast_mem, INTEGER_S8, 1, true, 0x7F)};
-    builtin_types[BUILTIN_TYPE_U16] =
-        (BuiltinType){.name = "u16", .type = type_int_alloc(ast_mem, INTEGER_U16, 2, false, 0xFFFF)};
-    builtin_types[BUILTIN_TYPE_S16] =
-        (BuiltinType){.name = "s16", .type = type_int_alloc(ast_mem, INTEGER_S16, 2, true, 0x7FFF)};
-    builtin_types[BUILTIN_TYPE_U32] =
-        (BuiltinType){.name = "u32", .type = type_int_alloc(ast_mem, INTEGER_U32, 4, false, 0xFFFFFFFF)};
-    builtin_types[BUILTIN_TYPE_S32] =
-        (BuiltinType){.name = "s32", .type = type_int_alloc(ast_mem, INTEGER_S32, 4, true, 0x7FFFFFFF)};
+    builtin_types[BUILTIN_TYPE_U8] = (BuiltinType){.name = "u8", .type = type_int_alloc(ast_mem, INTEGER_U8, 1, false, 0xFF)};
+    builtin_types[BUILTIN_TYPE_S8] = (BuiltinType){.name = "s8", .type = type_int_alloc(ast_mem, INTEGER_S8, 1, true, 0x7F)};
+    builtin_types[BUILTIN_TYPE_U16] = (BuiltinType){.name = "u16", .type = type_int_alloc(ast_mem, INTEGER_U16, 2, false, 0xFFFF)};
+    builtin_types[BUILTIN_TYPE_S16] = (BuiltinType){.name = "s16", .type = type_int_alloc(ast_mem, INTEGER_S16, 2, true, 0x7FFF)};
+    builtin_types[BUILTIN_TYPE_U32] = (BuiltinType){.name = "u32", .type = type_int_alloc(ast_mem, INTEGER_U32, 4, false, 0xFFFFFFFF)};
+    builtin_types[BUILTIN_TYPE_S32] = (BuiltinType){.name = "s32", .type = type_int_alloc(ast_mem, INTEGER_S32, 4, true, 0x7FFFFFFF)};
     builtin_types[BUILTIN_TYPE_U64] =
         (BuiltinType){.name = "u64", .type = type_int_alloc(ast_mem, INTEGER_U64, 8, false, 0xFFFFFFFFFFFFFFFF)};
     builtin_types[BUILTIN_TYPE_S64] =
@@ -1103,9 +1093,8 @@ void init_builtin_types(OS target_os, Arch target_arch, Allocator* ast_mem, Type
 //////////////////////////////
 
 const SymbolKind decl_sym_kind[CST_DECL_KIND_COUNT] = {
-    [CST_DECL_NONE] = SYMBOL_NONE, [CST_DeclVar] = SYMBOL_VAR,      [CST_DeclConst] = SYMBOL_CONST,
-    [CST_DeclEnum] = SYMBOL_TYPE,  [CST_DeclUnion] = SYMBOL_TYPE,   [CST_DeclStruct] = SYMBOL_TYPE,
-    [CST_DeclProc] = SYMBOL_PROC,  [CST_DeclTypedef] = SYMBOL_TYPE,
+    [CST_DECL_NONE] = SYMBOL_NONE, [CST_DeclVar] = SYMBOL_VAR,     [CST_DeclConst] = SYMBOL_CONST, [CST_DeclEnum] = SYMBOL_TYPE,
+    [CST_DeclUnion] = SYMBOL_TYPE, [CST_DeclStruct] = SYMBOL_TYPE, [CST_DeclProc] = SYMBOL_PROC,   [CST_DeclTypedef] = SYMBOL_TYPE,
 };
 
 const char* sym_kind_names[SYMBOL_KIND_COUNT] = {
@@ -1317,8 +1306,7 @@ static bool install_module_decl(Allocator* allocator, Module* mod, Decl* decl)
                 enum_item_val = new_expr_int(allocator, token_zero, dummy_range);
             }
 
-            Decl* enum_item_const =
-                new_decl_const(allocator, enum_item->name, enum_item_typespec, enum_item_val, enum_item->range);
+            Decl* enum_item_const = new_decl_const(allocator, enum_item->name, enum_item_typespec, enum_item_val, enum_item->range);
 
             if (!install_module_decl(allocator, mod, enum_item_const)) {
                 return false;
@@ -1419,8 +1407,7 @@ bool import_mod_syms(Module* dst_mod, Module* src_mod, StmtImport* stmt)
         Symbol* sym = module_get_export_sym(src_mod, isym->name);
 
         if (!sym) {
-            report_error(stmt->super.range, "Importing unknown or private symbol `%s` from module `%s`",
-                         isym->name->str,
+            report_error(stmt->super.range, "Importing unknown or private symbol `%s` from module `%s`", isym->name->str,
                          src_mod->cpath_lit->str); // TODO: mod_path is not an OS path
             return false;
         }
@@ -1525,8 +1512,7 @@ char* ftprint_typespec(Allocator* allocator, TypeSpec* typespec)
                     ProcParam* param = list_entry(it, ProcParam, lnode);
 
                     if (param->name->str)
-                        ftprint_char_array(&dstr, false, "(%s %s)", param->name->str,
-                                           ftprint_typespec(allocator, param->typespec));
+                        ftprint_char_array(&dstr, false, "(%s %s)", param->name->str, ftprint_typespec(allocator, param->typespec));
                     else
                         ftprint_char_array(&dstr, false, "%s", ftprint_typespec(allocator, param->typespec));
 
@@ -1554,8 +1540,7 @@ char* ftprint_typespec(Allocator* allocator, TypeSpec* typespec)
                 for (ListNode* it = head->next; it != head; it = it->next) {
                     AggregateField* field = list_entry(it, AggregateField, lnode);
 
-                    ftprint_char_array(&dstr, false, "(%s %s)", field->name->str,
-                                       ftprint_typespec(allocator, field->typespec));
+                    ftprint_char_array(&dstr, false, "(%s %s)", field->name->str, ftprint_typespec(allocator, field->typespec));
 
                     if (it->next != head)
                         ftprint_char_array(&dstr, false, " ");
@@ -1613,8 +1598,8 @@ char* ftprint_expr(Allocator* allocator, Expr* expr)
         case CST_ExprTernary: {
             ExprTernary* e = (ExprTernary*)expr;
             dstr = array_create(allocator, char, 32);
-            ftprint_char_array(&dstr, false, "(? %s %s %s)", ftprint_expr(allocator, e->cond),
-                               ftprint_expr(allocator, e->then_expr), ftprint_expr(allocator, e->else_expr));
+            ftprint_char_array(&dstr, false, "(? %s %s %s)", ftprint_expr(allocator, e->cond), ftprint_expr(allocator, e->then_expr),
+                               ftprint_expr(allocator, e->else_expr));
         } break;
         case CST_ExprBinary: {
             ExprBinary* e = (ExprBinary*)expr;
@@ -1657,8 +1642,7 @@ char* ftprint_expr(Allocator* allocator, Expr* expr)
         case CST_ExprIndex: {
             ExprIndex* e = (ExprIndex*)expr;
             dstr = array_create(allocator, char, 8);
-            ftprint_char_array(&dstr, false, "(index %s %s)", ftprint_expr(allocator, e->array),
-                               ftprint_expr(allocator, e->index));
+            ftprint_char_array(&dstr, false, "(index %s %s)", ftprint_expr(allocator, e->array), ftprint_expr(allocator, e->index));
         } break;
         case CST_ExprField: {
             ExprField* e = (ExprField*)expr;
@@ -1815,22 +1799,19 @@ char* ftprint_stmt(Allocator* allocator, Stmt* stmt)
             dstr = array_create(allocator, char, 32);
             const char* op = token_kind_names[s->op_assign];
 
-            ftprint_char_array(&dstr, false, "(%s %s %s)", op, ftprint_expr(allocator, s->left),
-                               ftprint_expr(allocator, s->right));
+            ftprint_char_array(&dstr, false, "(%s %s %s)", op, ftprint_expr(allocator, s->left), ftprint_expr(allocator, s->right));
         } break;
         case CST_StmtWhile: {
             StmtWhile* s = (StmtWhile*)stmt;
             dstr = array_create(allocator, char, 32);
 
-            ftprint_char_array(&dstr, false, "(while %s %s)", ftprint_expr(allocator, s->cond),
-                               ftprint_stmt(allocator, s->body));
+            ftprint_char_array(&dstr, false, "(while %s %s)", ftprint_expr(allocator, s->cond), ftprint_stmt(allocator, s->body));
         } break;
         case CST_StmtDoWhile: {
             StmtDoWhile* s = (StmtDoWhile*)stmt;
             dstr = array_create(allocator, char, 32);
 
-            ftprint_char_array(&dstr, false, "(do-while %s %s)", ftprint_expr(allocator, s->cond),
-                               ftprint_stmt(allocator, s->body));
+            ftprint_char_array(&dstr, false, "(do-while %s %s)", ftprint_expr(allocator, s->cond), ftprint_stmt(allocator, s->body));
         } break;
         case CST_StmtFor: {
             StmtFor* s = (StmtFor*)stmt;
@@ -2080,8 +2061,7 @@ char* ftprint_decl(Allocator* allocator, Decl* decl)
         case CST_DeclTypedef: {
             DeclTypedef* d = (DeclTypedef*)decl;
             dstr = array_create(allocator, char, 32);
-            ftprint_char_array(&dstr, false, "(typedef %s %s)", decl->name->str,
-                               ftprint_typespec(allocator, d->typespec));
+            ftprint_char_array(&dstr, false, "(typedef %s %s)", decl->name->str, ftprint_typespec(allocator, d->typespec));
         } break;
         case CST_DeclEnum: {
             DeclEnum* d = (DeclEnum*)decl;
@@ -2117,8 +2097,7 @@ char* ftprint_decl(Allocator* allocator, Decl* decl)
             DeclAggregate* d = (DeclAggregate*)decl;
             dstr = array_create(allocator, char, 32);
 
-            ftprint_char_array(&dstr, false, "(%s %s", (decl->kind == CST_DeclStruct ? "struct" : "union"),
-                               decl->name->str);
+            ftprint_char_array(&dstr, false, "(%s %s", (decl->kind == CST_DeclStruct ? "struct" : "union"), decl->name->str);
 
             if (!list_empty(&d->fields)) {
                 ftprint_char_array(&dstr, false, " ");
@@ -2128,8 +2107,7 @@ char* ftprint_decl(Allocator* allocator, Decl* decl)
                 for (List* it = head->next; it != head; it = it->next) {
                     AggregateField* field = list_entry(it, AggregateField, lnode);
 
-                    ftprint_char_array(&dstr, false, "(%s %s)", field->name->str,
-                                       ftprint_typespec(allocator, field->typespec));
+                    ftprint_char_array(&dstr, false, "(%s %s)", field->name->str, ftprint_typespec(allocator, field->typespec));
 
                     if (it->next != head)
                         ftprint_char_array(&dstr, false, " ");

--- a/src/ast.h
+++ b/src/ast.h
@@ -144,6 +144,7 @@ struct Expr {
     Type* type;
     bool is_constexpr;
     bool is_lvalue;
+    bool is_imm;
     Scalar const_val;
 };
 

--- a/src/ast.h
+++ b/src/ast.h
@@ -214,6 +214,8 @@ typedef struct ExprIdent {
     Expr super;
     Identifier* mod_ns;
     Identifier* name;
+    // TODO: Remove. This is messy.
+    Symbol* sym;
 } ExprIdent;
 
 typedef struct ExprCast {

--- a/src/ast.h
+++ b/src/ast.h
@@ -23,6 +23,10 @@ typedef struct SymbolModule SymbolModule;
 typedef struct Scope Scope;
 typedef struct Module Module;
 
+typedef struct ConstAddr ConstAddr;
+typedef struct ConstArrayMemberInitzer ConstArrayMemberInitzer;
+typedef struct ConstArrayInitzer ConstArrayInitzer;
+typedef struct ConstExpr ConstExpr;
 ///////////////////////////////
 //       Type Specifiers
 //////////////////////////////
@@ -754,10 +758,66 @@ typedef enum SymbolStatus {
     SYMBOL_STATUS_RESOLVED,
 } SymbolStatus;
 
+typedef enum ConstExprKind {
+    CONST_EXPR_NONE = 0,
+    CONST_EXPR_IMM,
+    CONST_EXPR_MEM_ADDR,
+    CONST_EXPR_DEREF_ADDR,
+    CONST_EXPR_ARRAY_INIT,
+    CONST_EXPR_VAR,
+    CONST_EXPR_PROC,
+    CONST_EXPR_STR_LIT
+} ConstExprKind;
+
+typedef enum ConstAddrKind {
+    CONST_ADDR_SYM,
+    CONST_ADDR_STR_LIT
+} ConstAddrKind;
+
+struct ConstAddr {
+    ConstAddrKind kind;
+
+    union {
+        Symbol* sym;
+        StrLit* str_lit;
+    };
+
+    u8 scale;
+    u32 disp;
+};
+
+struct ConstArrayInitzer {
+    size_t num_initzers;
+    ConstArrayMemberInitzer* initzers;
+};
+
+struct ConstExpr {
+    ConstExprKind kind;
+    Type* type;
+
+    union {
+        Scalar imm;
+        ConstAddr addr;
+        Symbol* sym;
+        StrLit* str_lit;
+        ConstArrayInitzer array_initzer;
+    };
+};
+
+struct ConstArrayMemberInitzer {
+    size_t index;
+    ConstExpr const_expr;
+};
+
 struct SymbolVar {
-    // Used by backends to store this var's
-    // location in the stack.
-    s32 offset;
+    union {
+        // Used by backends to store this var's
+        // location in the stack.
+        s32 offset;
+
+        // Used to describe initial value (constexpr) for global variable
+        ConstExpr const_expr;
+    };
 };
 
 typedef struct LifetimeInterval {

--- a/src/ast.h
+++ b/src/ast.h
@@ -218,8 +218,6 @@ typedef struct ExprIdent {
     Expr super;
     Identifier* mod_ns;
     Identifier* name;
-    // TODO: Remove. This is messy.
-    Symbol* sym;
 } ExprIdent;
 
 typedef struct ExprCast {
@@ -782,7 +780,6 @@ struct ConstAddr {
         StrLit* str_lit;
     };
 
-    u8 scale;
     u32 disp;
 };
 

--- a/src/ast.h
+++ b/src/ast.h
@@ -145,7 +145,7 @@ struct Expr {
     bool is_constexpr;
     bool is_lvalue;
     bool is_imm;
-    Scalar const_val;
+    Scalar imm;
 };
 
 typedef struct ExprTernary {

--- a/src/bytecode.c
+++ b/src/bytecode.c
@@ -1127,6 +1127,7 @@ static void IR_emit_expr_ident(IR_Builder* builder, ExprIdent* eident, IR_Operan
     }
 
     assert(sym);
+    assert(sym == eident->sym);
 
     IR_operand_from_sym(dst, sym);
 }

--- a/src/bytecode.h
+++ b/src/bytecode.h
@@ -392,6 +392,6 @@ typedef struct IR_Instr {
     };
 } IR_Instr;
 
-void IR_gen_bytecode(Allocator* arena, Allocator* tmp_arena, BucketList* procs, TypeCache* type_cache);
+void IR_gen_bytecode(Allocator* arena, Allocator* tmp_arena, BucketList* vars, BucketList* procs, TypeCache* type_cache);
 
 #endif

--- a/src/bytecode/gen.c
+++ b/src/bytecode/gen.c
@@ -1,0 +1,11 @@
+#include "bytecode.h"
+
+#include "bytecode/vars.c"
+#include "bytecode/procs.c"
+
+
+void IR_gen_bytecode(Allocator* arena, Allocator* tmp_arena, BucketList* vars, BucketList* procs, TypeCache* type_cache)
+{
+    IR_build_vars(arena, tmp_arena, vars, type_cache);
+    IR_build_procs(arena, tmp_arena, procs, type_cache);
+}

--- a/src/bytecode/procs.c
+++ b/src/bytecode/procs.c
@@ -1117,7 +1117,6 @@ static void IR_emit_expr_ident(IR_ProcBuilder* builder, ExprIdent* eident, IR_Op
     if (eident->mod_ns) {
         Symbol* sym_modns = lookup_symbol(builder->curr_scope, eident->mod_ns);
         StmtImport* stmt = (StmtImport*)sym_modns->as_mod.stmt;
-
         Identifier* sym_name = get_import_sym_name(stmt, eident->name);
 
         sym = module_get_export_sym(sym_modns->as_mod.mod, sym_name);
@@ -1127,7 +1126,6 @@ static void IR_emit_expr_ident(IR_ProcBuilder* builder, ExprIdent* eident, IR_Op
     }
 
     assert(sym);
-    assert(sym == eident->sym);
 
     IR_operand_from_sym(dst, sym);
 }

--- a/src/bytecode/vars.c
+++ b/src/bytecode/vars.c
@@ -1,0 +1,243 @@
+#include "bytecode.h"
+
+typedef struct IR_VarBuilder {
+    Allocator* arena;
+    Allocator* tmp_arena;
+    TypeCache* type_cache;
+    Module* curr_mod;
+} IR_VarBuilder;
+
+static void IR_emit_global_expr(IR_VarBuilder* builder, Expr* expr, ConstExpr* dst);
+
+static void IR_const_expr_from_sym(ConstExpr* dst, Symbol* sym)
+{
+    if (sym->kind == SYMBOL_VAR) {
+        dst->kind = CONST_EXPR_VAR;
+        dst->type = sym->type;
+        dst->sym = sym;
+    }
+    else if (sym->kind == SYMBOL_PROC) {
+        dst->kind = CONST_EXPR_PROC;
+        dst->type = sym->type;
+        dst->sym = sym;
+    }
+    else {
+        assert(0);
+    }
+}
+
+static void IR_emit_global_expr_ident(IR_VarBuilder* builder, ExprIdent* eident, ConstExpr* dst)
+{
+    Symbol* sym = NULL;
+
+    if (eident->mod_ns) {
+        Symbol* sym_modns = lookup_symbol(&builder->curr_mod->scope, eident->mod_ns);
+        StmtImport* stmt = (StmtImport*)sym_modns->as_mod.stmt;
+        Identifier* sym_name = get_import_sym_name(stmt, eident->name);
+
+        sym = module_get_export_sym(sym_modns->as_mod.mod, sym_name);
+    }
+    else {
+        sym = lookup_symbol(&builder->curr_mod->scope, eident->name);
+    }
+
+    assert(sym);
+
+    IR_const_expr_from_sym(dst, sym);
+}
+
+static void IR_emit_global_expr_cast(IR_VarBuilder* builder, ExprCast* expr_cast, ConstExpr* dst)
+{
+    ConstExpr src = {0};
+    IR_emit_global_expr(builder, expr_cast->expr, &src);
+
+    dst->kind = CONST_EXPR_MEM_ADDR;
+    dst->type = expr_cast->super.type;
+
+    // Only casts from array to pointer should be encountered here. Because global expressions
+    // are compile-time constants, any int casts must have been processed in IR_emit_global_expr.
+    assert(src.type->kind == TYPE_ARRAY && dst->type->kind == TYPE_PTR);
+
+    if (src.kind == CONST_EXPR_VAR) {
+        assert(!src.sym->is_local);
+
+        dst->addr.kind = CONST_ADDR_SYM;
+        dst->addr.sym = src.sym;
+        dst->addr.scale = 0;
+        dst->addr.disp = 0;
+    }
+    else if (src.kind == CONST_EXPR_DEREF_ADDR) {
+        dst->addr = src.addr;        
+    }
+    else {
+        assert(src.kind == CONST_EXPR_STR_LIT);
+
+        dst->addr.kind = CONST_ADDR_STR_LIT;
+        dst->addr.str_lit = src.str_lit;
+        dst->addr.scale = 0;
+        dst->addr.disp = 0;
+    }
+}
+
+static void IR_emit_global_expr_unary(IR_VarBuilder* builder, ExprUnary* expr_unary, ConstExpr* dst)
+{
+    Type* result_type = expr_unary->super.type;
+
+    switch (expr_unary->op) {
+    case TKN_CARET: {
+        ConstExpr src = {0};
+
+        IR_emit_global_expr(builder, expr_unary->expr, &src);
+
+        dst->kind = CONST_EXPR_MEM_ADDR;
+        dst->type = result_type;
+
+        if (src.kind == CONST_EXPR_DEREF_ADDR) {
+            dst->addr = src.addr;
+        }
+        else {
+            assert(src.kind == CONST_EXPR_VAR);
+
+            dst->addr.kind = CONST_ADDR_SYM;
+            dst->addr.sym = src.sym;
+            dst->addr.scale = 0;
+            dst->addr.disp = 0;
+        }
+        break;
+    }
+    default:
+        assert(0);
+        break;
+    }
+}
+
+// TODO: Refactor wet code. Very similar to code used in bytecode/procs.c
+static void IR_emit_global_expr_compound_lit(IR_VarBuilder* builder, ExprCompoundLit* expr, ConstExpr* dst)
+{
+    // TODO: Currently only support array initializers.
+    assert(expr->super.type->kind == TYPE_ARRAY);
+    assert(!expr->typespec);
+
+    size_t initzer_index = 0;
+    ConstArrayMemberInitzer* const_initzers = alloc_array(builder->arena, ConstArrayMemberInitzer, expr->num_initzers, true);
+
+    List* head = &expr->initzers;
+    List* it = head->next;
+    size_t elem_index = 0;
+
+    while (it != head) {
+        MemberInitializer* initzer = list_entry(it, MemberInitializer, lnode);
+        ConstArrayMemberInitzer* ir_initzer = const_initzers + initzer_index;
+
+        if (initzer->designator.kind == DESIGNATOR_INDEX) {
+            ConstExpr desig_op = {0};
+            IR_emit_global_expr(builder, initzer->designator.index, &desig_op);
+
+            assert(desig_op.kind == CONST_EXPR_IMM);
+            elem_index = desig_op.imm.as_int._u64;
+        }
+        else {
+            assert(initzer->designator.kind == DESIGNATOR_NONE);
+        }
+
+        ir_initzer->index = elem_index;
+        IR_emit_global_expr(builder, initzer->init, &ir_initzer->const_expr);
+
+        elem_index += 1;
+        initzer_index += 1;
+        it = it->next;
+    }
+
+    dst->kind = CONST_EXPR_ARRAY_INIT;
+    dst->type = expr->super.type;
+    dst->array_initzer.num_initzers = expr->num_initzers;
+    dst->array_initzer.initzers = const_initzers;
+}
+
+static void IR_emit_global_expr(IR_VarBuilder* builder, Expr* expr, ConstExpr* dst)
+{
+    if (expr->is_constexpr && expr->is_imm) {
+        assert(type_is_scalar(expr->type));
+        dst->kind = CONST_EXPR_IMM;
+        dst->type = expr->type;
+        dst->imm = expr->imm;
+
+        return;
+    }
+
+    switch (expr->kind) {
+    case CST_ExprIdent:
+        IR_emit_global_expr_ident(builder, (ExprIdent*)expr, dst);
+        break;
+    case CST_ExprCast:
+        IR_emit_global_expr_cast(builder, (ExprCast*)expr, dst);
+        break;
+    case CST_ExprBinary:
+        //IR_emit_expr_binary(builder, (ExprBinary*)expr, dst);
+        assert(0);
+        break;
+    case CST_ExprUnary:
+        IR_emit_global_expr_unary(builder, (ExprUnary*)expr, dst);
+        break;
+    case CST_ExprIndex:
+        //IR_emit_expr_index(builder, (ExprIndex*)expr, dst);
+        assert(0);
+        break;
+    case CST_ExprCompoundLit:
+        IR_emit_global_expr_compound_lit(builder, (ExprCompoundLit*)expr, dst);
+        break;
+    case CST_ExprStr: {
+        ExprStr* expr_str_lit = (ExprStr*)expr;
+
+        dst->kind = CONST_EXPR_STR_LIT;
+        dst->type = expr_str_lit->super.type;
+        dst->str_lit = expr_str_lit->str_lit;
+
+        break;
+    }
+    default:
+        ftprint_err("[INTERNAL ERROR]: Unsupported expr kind %d during global var expr generation\n", expr->kind);
+        assert(0);
+        break;
+    }
+}
+static void IR_build_var(IR_VarBuilder* builder, Symbol* sym)
+{
+    builder->curr_mod = sym->home;
+
+    DeclVar* decl_var = (DeclVar*)sym->decl;
+    ConstExpr const_expr = {.type = sym->type};
+
+    if (decl_var->init) {
+        IR_emit_global_expr(builder, decl_var->init, &const_expr);
+    }
+
+    sym->as_var.const_expr = const_expr;
+}
+
+static void IR_build_vars(Allocator* arena, Allocator* tmp_arena, BucketList* vars, TypeCache* type_cache)
+{
+    IR_VarBuilder builder = {
+        .arena = arena,
+        .tmp_arena = tmp_arena,
+        .type_cache = type_cache,
+        .curr_mod = NULL
+    };
+
+    AllocatorState tmp_mem_state = allocator_get_state(builder.tmp_arena);
+
+    // Iterate through all global variables and generate operands.
+    size_t num_vars = vars->num_elems;
+
+    for (size_t i = 0; i < num_vars; i += 1) {
+        void** sym_ptr = bucket_list_get_elem_packed(vars, i);
+        assert(sym_ptr);
+        Symbol* sym = (Symbol*)(*sym_ptr);
+        assert(sym->kind == SYMBOL_VAR);
+
+        IR_build_var(&builder, sym);
+    }
+
+    allocator_restore_state(tmp_mem_state);
+}
+

--- a/src/bytecode/vars.c
+++ b/src/bytecode/vars.c
@@ -63,7 +63,6 @@ static void IR_emit_global_expr_cast(IR_VarBuilder* builder, ExprCast* expr_cast
 
         dst->addr.kind = CONST_ADDR_SYM;
         dst->addr.sym = src.sym;
-        dst->addr.scale = 0;
         dst->addr.disp = 0;
     }
     else if (src.kind == CONST_EXPR_DEREF_ADDR) {
@@ -74,7 +73,6 @@ static void IR_emit_global_expr_cast(IR_VarBuilder* builder, ExprCast* expr_cast
 
         dst->addr.kind = CONST_ADDR_STR_LIT;
         dst->addr.str_lit = src.str_lit;
-        dst->addr.scale = 0;
         dst->addr.disp = 0;
     }
 }
@@ -100,7 +98,6 @@ static void IR_emit_global_expr_unary(IR_VarBuilder* builder, ExprUnary* expr_un
 
             dst->addr.kind = CONST_ADDR_SYM;
             dst->addr.sym = src.sym;
-            dst->addr.scale = 0;
             dst->addr.disp = 0;
         }
         break;
@@ -109,6 +106,11 @@ static void IR_emit_global_expr_unary(IR_VarBuilder* builder, ExprUnary* expr_un
         assert(0);
         break;
     }
+}
+
+static void IR_emit_global_expr_binary(IR_VarBuilder* builder, ExprBinary* expr_binary, ConstExpr* dst)
+{
+
 }
 
 // TODO: Refactor wet code. Very similar to code used in bytecode/procs.c

--- a/src/main.c
+++ b/src/main.c
@@ -23,7 +23,7 @@
 #include "ast.c"
 #include "parser.c"
 #include "resolver.c"
-#include "bytecode.c"
+#include "bytecode/gen.c"
 #include "print_ir.c"
 #include "code_gen.c"
 #include "x64_gen/gen.c"

--- a/src/main.c
+++ b/src/main.c
@@ -7,6 +7,7 @@
 
 //#define NDEBUG
 //#define NIBBLE_PRINT_DECLS
+//#define NIBBLE_PRINT_MEM_USAGE
 
 // This is a "unity build".
 // Having a single compilation unit makes building trivial.

--- a/src/nibble.c
+++ b/src/nibble.c
@@ -1092,7 +1092,7 @@ bool nibble_compile(const char* mainf_name, size_t mainf_len, const char* outf_n
     //////////////////////////////////////////
     //          Gen IR bytecode
     //////////////////////////////////////////
-    IR_gen_bytecode(&nibble->ast_mem, &nibble->tmp_mem, &nibble->procs, &nibble->type_cache);
+    IR_gen_bytecode(&nibble->ast_mem, &nibble->tmp_mem, &nibble->vars, &nibble->procs, &nibble->type_cache);
 
     //////////////////////////////////////////
     //          Gen NASM output

--- a/src/nibble.c
+++ b/src/nibble.c
@@ -1182,7 +1182,7 @@ bool nibble_compile(const char* mainf_name, size_t mainf_len, const char* outf_n
 
 void nibble_cleanup(void)
 {
-#ifndef NDEBUG
+#ifdef NIBBLE_PRINT_MEM_USAGE
     print_allocator_stats(&nibble->gen_mem, "GEN mem stats");
     print_allocator_stats(&nibble->ast_mem, "AST mem stats");
     print_allocator_stats(&nibble->tmp_mem, "TMP mem stats");

--- a/src/nibble.c
+++ b/src/nibble.c
@@ -1182,7 +1182,7 @@ bool nibble_compile(const char* mainf_name, size_t mainf_len, const char* outf_n
 
 void nibble_cleanup(void)
 {
-#ifdef NIBBLE_PRINT_DECLS
+#ifndef NDEBUG
     print_allocator_stats(&nibble->gen_mem, "GEN mem stats");
     print_allocator_stats(&nibble->ast_mem, "AST mem stats");
     print_allocator_stats(&nibble->tmp_mem, "TMP mem stats");

--- a/src/parser.c
+++ b/src/parser.c
@@ -667,6 +667,8 @@ static Expr* parse_expr_base(Parser* parser)
             return NULL;
         }
 
+        enclosed->range.start = token.range.start;
+        enclosed->range.end = parser->token.range.end;
         return enclosed;
     } break;
     case TKN_LBRACE:

--- a/src/resolver.c
+++ b/src/resolver.c
@@ -1300,9 +1300,12 @@ static bool resolve_expr_unary(Resolver* resolver, Expr* expr)
             return false;
         }
 
+        // The following determines whether this expression is a `constexpr`.
+        // Ex: The address of a global variable is a constant expression
+        //
+        // This does not seem like the best way to do this, so this code will probably go away.
         bool is_constexpr = false;
 
-        // The address of a global variable is a constant expression
         if (eunary->expr->kind == CST_ExprIdent) {
             ExprIdent* expr_ident = (ExprIdent*)eunary->expr;
             Symbol* sym = lookup_ident(resolver, expr_ident);

--- a/src/resolver.c
+++ b/src/resolver.c
@@ -1438,6 +1438,9 @@ static bool resolve_expr_ident(Resolver* resolver, Expr* expr)
         return false;
     }
 
+    // TODO: Remove. This is messy.
+    eident->sym = sym;
+
     switch (sym->kind) {
     case SYMBOL_VAR:
         expr->type = sym->type;

--- a/src/resolver.c
+++ b/src/resolver.c
@@ -1438,9 +1438,6 @@ static bool resolve_expr_ident(Resolver* resolver, Expr* expr)
         return false;
     }
 
-    // TODO: Remove. This is messy.
-    eident->sym = sym;
-
     switch (sym->kind) {
     case SYMBOL_VAR:
         expr->type = sym->type;

--- a/src/x64_gen/gen.c
+++ b/src/x64_gen/gen.c
@@ -264,6 +264,7 @@ static void X64_print_global_arr_init(Allocator* allocator, ExprCompoundLit* ini
 
         if (initzer->designator.kind == DESIGNATOR_INDEX) {
             assert(initzer->designator.index->is_constexpr);
+            assert(initzer->designator.index->is_imm);
             elem_index = initzer->designator.index->const_val.as_int._u64;
         }
 

--- a/src/x64_gen/gen.c
+++ b/src/x64_gen/gen.c
@@ -328,7 +328,7 @@ static void X64_print_global_val(Allocator* allocator, ConstExpr* const_expr, ch
         }
 
         if (addr->disp) {
-            ftprint_char_array(line, false, "+ %d", (s32)addr->disp);
+            ftprint_char_array(line, false, " + %d", (s32)addr->disp);
         }
 
         ftprint_char_array(line, false, "\n");

--- a/src/x64_gen/gen.c
+++ b/src/x64_gen/gen.c
@@ -86,14 +86,12 @@ static const char* x64_reg_names[X64_MAX_INT_REG_SIZE + 1][X64_REG_COUNT] = {
         },
 };
 
-static const char* x64_mem_size_label[X64_MAX_INT_REG_SIZE + 1] =
-    {[1] = "byte", [2] = "word", [4] = "dword", [8] = "qword"};
+static const char* x64_mem_size_label[X64_MAX_INT_REG_SIZE + 1] = {[1] = "byte", [2] = "word", [4] = "dword", [8] = "qword"};
 static const char* x64_data_size_label[X64_MAX_INT_REG_SIZE + 1] = {[1] = "db", [2] = "dw", [4] = "dd", [8] = "dq"};
 
 static const char* x64_condition_codes[] = {
-    [IR_COND_U_LT] = "b", [IR_COND_S_LT] = "l", [IR_COND_U_LTEQ] = "be", [IR_COND_S_LTEQ] = "le",
-    [IR_COND_U_GT] = "a", [IR_COND_S_GT] = "g", [IR_COND_U_GTEQ] = "ae", [IR_COND_S_GTEQ] = "ge",
-    [IR_COND_EQ] = "e",   [IR_COND_NEQ] = "ne",
+    [IR_COND_U_LT] = "b", [IR_COND_S_LT] = "l",    [IR_COND_U_LTEQ] = "be", [IR_COND_S_LTEQ] = "le", [IR_COND_U_GT] = "a",
+    [IR_COND_S_GT] = "g", [IR_COND_U_GTEQ] = "ae", [IR_COND_S_GTEQ] = "ge", [IR_COND_EQ] = "e",      [IR_COND_NEQ] = "ne",
 };
 
 static const char* x64_sext_ax_into_dx[X64_MAX_INT_REG_SIZE + 1] = {[2] = "cwd", [4] = "cdq", [8] = "cqo"};
@@ -154,8 +152,7 @@ static X64_VRegLoc X64_vreg_loc(X64_Generator* generator, IR_Reg ir_reg)
     return reg_loc;
 }
 
-static char** X64_emit_line(BucketList* sstream, Allocator* gen_mem, Allocator* tmp_mem, const char* format,
-                            va_list vargs)
+static char** X64_emit_line(BucketList* sstream, Allocator* gen_mem, Allocator* tmp_mem, const char* format, va_list vargs)
 {
     char** line_ptr = NULL;
 
@@ -265,7 +262,7 @@ static void X64_print_global_arr_init(Allocator* allocator, ExprCompoundLit* ini
         if (initzer->designator.kind == DESIGNATOR_INDEX) {
             assert(initzer->designator.index->is_constexpr);
             assert(initzer->designator.index->is_imm);
-            elem_index = initzer->designator.index->const_val.as_int._u64;
+            elem_index = initzer->designator.index->imm.as_int._u64;
         }
 
         assert(initzer->init->is_constexpr);
@@ -299,7 +296,7 @@ static void X64_print_global_arr_elem(Allocator* allocator, Expr* elem, char** l
 
     if (elem->type->kind == TYPE_INTEGER) {
         size_t num_bytes = elem->type->size;
-        u64 elem_val = elem->const_val.as_int._u64;
+        u64 elem_val = elem->imm.as_int._u64;
         u64 mask = 0xFFLL;
 
         ftprint_char_array(line, false, "%s ", x64_data_size_label[1]);
@@ -326,7 +323,6 @@ static void X64_print_global_arr_elem(Allocator* allocator, Expr* elem, char** l
                 assert(expr_unary->op == TKN_CARET);
                 e = expr_unary->expr;
                 continue;
-
             }
             else if (e->kind == CST_ExprCast) {
                 ExprCast* expr_cast = (ExprCast*)e;
@@ -337,14 +333,13 @@ static void X64_print_global_arr_elem(Allocator* allocator, Expr* elem, char** l
             else if (e->kind == CST_ExprStr) {
                 ExprStr* expr_str = (ExprStr*)e;
 
-                ftprint_char_array(line, false, " %s %s_%llu\n",
-                                   x64_data_size_label[elem->type->size], X64_STR_LIT_PRE, expr_str->str_lit->id);
+                ftprint_char_array(line, false, " %s %s_%llu\n", x64_data_size_label[elem->type->size], X64_STR_LIT_PRE,
+                                   expr_str->str_lit->id);
                 break;
             }
             else {
                 assert(0);
             }
-
         }
 
         return;
@@ -389,7 +384,7 @@ static void X64_emit_global_data(X64_Generator* generator, Symbol* sym)
 
     switch (type->kind) {
     case TYPE_INTEGER: {
-        Scalar val = init ? init->const_val : (Scalar){0};
+        Scalar val = init ? init->imm : (Scalar){0};
         X64_emit_data(generator, "%s %s\n", x64_data_size_label[type->size], X64_print_imm(tmp_mem, val, type->size));
         break;
     }
@@ -429,7 +424,7 @@ static void X64_emit_global_data(X64_Generator* generator, Symbol* sym)
             AllocatorState mem_state = allocator_get_state(tmp_mem);
             char* line = array_create(tmp_mem, char, num_elems << 3);
 
-            //ftprint_char_array(&line, false, "%s ", x64_data_size_label[1]);
+            // ftprint_char_array(&line, false, "%s ", x64_data_size_label[1]);
 
             X64_print_global_arr_init(tmp_mem, (ExprCompoundLit*)init, &line);
 
@@ -615,9 +610,8 @@ typedef struct X64_StackArgsInfo {
     u64 args_offset;
 } X64_StackArgsInfo;
 
-static X64_StackArgsInfo X64_linux_preprocess_call_args(X64_Generator* generator, u32 live_regs, u32 num_args,
-                                                        IR_InstrCallArg* args, X64_ArgInfo* arg_infos,
-                                                        X64_ArgInfo** arg_info_map)
+static X64_StackArgsInfo X64_linux_preprocess_call_args(X64_Generator* generator, u32 live_regs, u32 num_args, IR_InstrCallArg* args,
+                                                        X64_ArgInfo* arg_infos, X64_ArgInfo** arg_info_map)
 {
     X64_StackArgsInfo stack_info = {0};
     u32 arg_reg_index = 0;
@@ -655,9 +649,8 @@ static X64_StackArgsInfo X64_linux_preprocess_call_args(X64_Generator* generator
     return stack_info;
 }
 
-static X64_StackArgsInfo X64_windows_preprocess_call_args(X64_Generator* generator, u32 live_regs, u32 num_args,
-                                                          IR_InstrCallArg* args, X64_ArgInfo* arg_infos,
-                                                          X64_ArgInfo** arg_info_map)
+static X64_StackArgsInfo X64_windows_preprocess_call_args(X64_Generator* generator, u32 live_regs, u32 num_args, IR_InstrCallArg* args,
+                                                          X64_ArgInfo* arg_infos, X64_ArgInfo** arg_info_map)
 {
     X64_StackArgsInfo stack_info = {.args_size = X64_WINDOWS_SHADOW_SPACE, .args_offset = X64_WINDOWS_SHADOW_SPACE};
 
@@ -694,9 +687,8 @@ static X64_StackArgsInfo X64_windows_preprocess_call_args(X64_Generator* generat
     return stack_info;
 }
 
-static X64_StackArgsInfo X64_preprocess_call_args(X64_Generator* generator, u32 live_regs, u32 num_args,
-                                                  IR_InstrCallArg* args, X64_ArgInfo* arg_infos,
-                                                  X64_ArgInfo** arg_info_map)
+static X64_StackArgsInfo X64_preprocess_call_args(X64_Generator* generator, u32 live_regs, u32 num_args, IR_InstrCallArg* args,
+                                                  X64_ArgInfo* arg_infos, X64_ArgInfo** arg_info_map)
 {
     if (x64_target.os == OS_LINUX) {
         return X64_linux_preprocess_call_args(generator, live_regs, num_args, args, arg_infos, arg_info_map);
@@ -705,8 +697,7 @@ static X64_StackArgsInfo X64_preprocess_call_args(X64_Generator* generator, u32 
     return X64_windows_preprocess_call_args(generator, live_regs, num_args, args, arg_infos, arg_info_map);
 }
 
-static void X64_place_args_in_regs(X64_RegGroup* save_reg_group, u32 num_args, X64_ArgInfo* arg_infos,
-                                   X64_ArgInfo** arg_info_map)
+static void X64_place_args_in_regs(X64_RegGroup* save_reg_group, u32 num_args, X64_ArgInfo* arg_infos, X64_ArgInfo** arg_info_map)
 {
     X64_Generator* generator = save_reg_group->generator;
 
@@ -804,8 +795,7 @@ static void X64_place_args_in_regs(X64_RegGroup* save_reg_group, u32 num_args, X
     }
 }
 
-static void X64_place_args_in_stack(X64_Generator* generator, X64_StackArgsInfo stack_args_info, u32 num_args,
-                                    X64_ArgInfo* arg_infos)
+static void X64_place_args_in_stack(X64_Generator* generator, X64_StackArgsInfo stack_args_info, u32 num_args, X64_ArgInfo* arg_infos)
 {
     u64 stack_args_size = stack_args_info.args_size;
 
@@ -870,8 +860,7 @@ typedef struct X64_StackParamsInfo {
     List* local_var_iter; // Iterator pointing to the first local variable (if any) of the proc
 } X64_StackParamsInfo;
 
-static void X64_linux_assign_proc_param_offsets(X64_Generator* generator, DeclProc* dproc,
-                                                X64_StackParamsInfo* stack_params_info)
+static void X64_linux_assign_proc_param_offsets(X64_Generator* generator, DeclProc* dproc, X64_StackParamsInfo* stack_params_info)
 {
     u64 stack_spill_size = 0;
     u32 index = 0;
@@ -926,8 +915,7 @@ static void X64_linux_assign_proc_param_offsets(X64_Generator* generator, DeclPr
     stack_params_info->local_var_iter = it;
 }
 
-static void X64_windows_assign_proc_param_offsets(X64_Generator* generator, DeclProc* dproc,
-                                                  X64_StackParamsInfo* stack_params_info)
+static void X64_windows_assign_proc_param_offsets(X64_Generator* generator, DeclProc* dproc, X64_StackParamsInfo* stack_params_info)
 {
     u32 index = 0;
     u64 stack_arg_offset = 0x10;
@@ -974,8 +962,7 @@ static void X64_windows_assign_proc_param_offsets(X64_Generator* generator, Decl
     stack_params_info->local_var_iter = it;
 }
 
-static void X64_assign_proc_param_offsets(X64_Generator* generator, DeclProc* dproc,
-                                          X64_StackParamsInfo* stack_params_info)
+static void X64_assign_proc_param_offsets(X64_Generator* generator, DeclProc* dproc, X64_StackParamsInfo* stack_params_info)
 {
     if (x64_target.os == OS_LINUX) {
         X64_linux_assign_proc_param_offsets(generator, dproc, stack_params_info);
@@ -1172,11 +1159,10 @@ static char* X64_print_sibd_addr(Allocator* allocator, X64_SIBDAddr* addr, u32 m
                 const char* index_reg_name = x64_reg_names[X64_MAX_INT_REG_SIZE][addr->local.index_reg];
 
                 if (has_disp)
-                    ftprint_char_array(&dstr, false, "%s [%s + %d*%s + %d]", mem_label, base_reg_name,
-                                       addr->local.scale, index_reg_name, (s32)addr->local.disp);
+                    ftprint_char_array(&dstr, false, "%s [%s + %d*%s + %d]", mem_label, base_reg_name, addr->local.scale,
+                                       index_reg_name, (s32)addr->local.disp);
                 else
-                    ftprint_char_array(&dstr, false, "%s [%s + %d*%s]", mem_label, base_reg_name, addr->local.scale,
-                                       index_reg_name);
+                    ftprint_char_array(&dstr, false, "%s [%s + %d*%s]", mem_label, base_reg_name, addr->local.scale, index_reg_name);
             }
             else {
                 if (has_disp)
@@ -1208,8 +1194,8 @@ static char* X64_print_mem(X64_RegGroup* group, IR_MemAddr* addr, u32 size)
     return X64_print_sibd_addr(group->generator->tmp_mem, &sibd_addr, size);
 }
 
-static void X64_emit_rr_instr(X64_Generator* generator, const char* instr, bool writes_op1, u32 op1_size,
-                              IR_Reg op1_vreg, u32 op2_size, IR_Reg op2_vreg)
+static void X64_emit_rr_instr(X64_Generator* generator, const char* instr, bool writes_op1, u32 op1_size, IR_Reg op1_vreg,
+                              u32 op2_size, IR_Reg op2_vreg)
 {
     X64_VRegLoc op1_loc = X64_vreg_loc(generator, op1_vreg);
     X64_VRegLoc op2_loc = X64_vreg_loc(generator, op2_vreg);
@@ -1234,8 +1220,7 @@ static void X64_emit_rr_instr(X64_Generator* generator, const char* instr, bool 
     case X64_VREG_LOC_STACK: {
         switch (op2_loc.kind) {
         case X64_VREG_LOC_REG:
-            X64_emit_text(generator, "    %s %s, %s", instr,
-                          X64_print_stack_offset(generator->tmp_mem, op1_loc.offset, op1_size),
+            X64_emit_text(generator, "    %s %s, %s", instr, X64_print_stack_offset(generator->tmp_mem, op1_loc.offset, op1_size),
                           x64_reg_names[op2_size][op2_loc.reg]);
             break;
         case X64_VREG_LOC_STACK: {
@@ -1274,8 +1259,7 @@ static void X64_emit_rr_instr(X64_Generator* generator, const char* instr, bool 
     }
 }
 
-static void X64_emit_ri_instr(X64_Generator* generator, const char* instr, u32 op1_size, IR_Reg op1_vreg, u32 op2_size,
-                              Scalar op2_imm)
+static void X64_emit_ri_instr(X64_Generator* generator, const char* instr, u32 op1_size, IR_Reg op1_vreg, u32 op2_size, Scalar op2_imm)
 {
     X64_VRegLoc op1_loc = X64_vreg_loc(generator, op1_vreg);
 
@@ -1286,8 +1270,7 @@ static void X64_emit_ri_instr(X64_Generator* generator, const char* instr, u32 o
         break;
     }
     case X64_VREG_LOC_STACK: {
-        X64_emit_text(generator, "    %s %s, %s", instr,
-                      X64_print_stack_offset(generator->tmp_mem, op1_loc.offset, op1_size),
+        X64_emit_text(generator, "    %s %s, %s", instr, X64_print_stack_offset(generator->tmp_mem, op1_loc.offset, op1_size),
                       X64_print_imm(generator->tmp_mem, op2_imm, op2_size));
         break;
     }
@@ -1297,32 +1280,30 @@ static void X64_emit_ri_instr(X64_Generator* generator, const char* instr, u32 o
     }
 }
 
-static void X64_emit_rm_instr(X64_Generator* generator, const char* instr, bool writes_op1, u32 op1_size,
-                              IR_Reg op1_vreg, u32 op2_size, IR_MemAddr* op2_vaddr)
+static void X64_emit_rm_instr(X64_Generator* generator, const char* instr, bool writes_op1, u32 op1_size, IR_Reg op1_vreg,
+                              u32 op2_size, IR_MemAddr* op2_vaddr)
 {
     X64_RegGroup tmp_group = X64_begin_reg_group(generator);
     X64_Reg op1_reg = X64_get_reg(&tmp_group, op1_vreg, op1_size, writes_op1);
 
-    X64_emit_text(generator, "    %s %s, %s", instr, x64_reg_names[op1_size][op1_reg],
-                  X64_print_mem(&tmp_group, op2_vaddr, op2_size));
+    X64_emit_text(generator, "    %s %s, %s", instr, x64_reg_names[op1_size][op1_reg], X64_print_mem(&tmp_group, op2_vaddr, op2_size));
 
     X64_end_reg_group(&tmp_group);
 }
 
-static void X64_emit_mr_instr(X64_Generator* generator, const char* instr, u32 op1_size, IR_MemAddr* op1_vaddr,
-                              u32 op2_size, IR_Reg op2_vreg)
+static void X64_emit_mr_instr(X64_Generator* generator, const char* instr, u32 op1_size, IR_MemAddr* op1_vaddr, u32 op2_size,
+                              IR_Reg op2_vreg)
 {
     X64_RegGroup tmp_group = X64_begin_reg_group(generator);
     X64_Reg op2_reg = X64_get_reg(&tmp_group, op2_vreg, op2_size, false);
 
-    X64_emit_text(generator, "    %s %s, %s", instr, X64_print_mem(&tmp_group, op1_vaddr, op1_size),
-                  x64_reg_names[op2_size][op2_reg]);
+    X64_emit_text(generator, "    %s %s, %s", instr, X64_print_mem(&tmp_group, op1_vaddr, op1_size), x64_reg_names[op2_size][op2_reg]);
 
     X64_end_reg_group(&tmp_group);
 }
 
-static void X64_emit_mi_instr(X64_Generator* generator, const char* instr, u32 op1_size, IR_MemAddr* op1_vaddr,
-                              u32 op2_size, Scalar op2_imm)
+static void X64_emit_mi_instr(X64_Generator* generator, const char* instr, u32 op1_size, IR_MemAddr* op1_vaddr, u32 op2_size,
+                              Scalar op2_imm)
 {
     X64_RegGroup tmp_group = X64_begin_reg_group(generator);
 
@@ -1356,8 +1337,8 @@ static void X64_emit_div_instr(X64_Generator* generator, const char* instr_name,
     }
 
     const char* rax_op_str = x64_reg_names[op_size][X64_RAX];
-    const char* dst_op_str = dst_in_reg ? x64_reg_names[op_size][dst_loc.reg] :
-                                          X64_print_stack_offset(generator->tmp_mem, dst_loc.offset, op_size);
+    const char* dst_op_str =
+        dst_in_reg ? x64_reg_names[op_size][dst_loc.reg] : X64_print_stack_offset(generator->tmp_mem, dst_loc.offset, op_size);
 
     // Move the value stored in the intended destination into rax
     if (!dst_in_rax) {
@@ -1458,8 +1439,8 @@ static void X64_gen_instr(X64_Generator* generator, u32 live_regs, u32 instr_ind
         X64_VRegLoc dst_loc = X64_vreg_loc(generator, instr->div_r_r.dst);
         X64_VRegLoc src_loc = X64_vreg_loc(generator, instr->div_r_r.src);
         bool src_is_reg = src_loc.kind == X64_VREG_LOC_REG;
-        const char* src_op_str = src_is_reg ? x64_reg_names[size][src_loc.reg] :
-                                              X64_print_stack_offset(generator->tmp_mem, src_loc.offset, size);
+        const char* src_op_str =
+            src_is_reg ? x64_reg_names[size][src_loc.reg] : X64_print_stack_offset(generator->tmp_mem, src_loc.offset, size);
         bool move_src_op = src_is_reg && ((src_loc.reg == X64_RAX) || (src_loc.reg == X64_RDX && uses_rdx));
 
         // Swap if the source operand is currently in rax or rdx.
@@ -1529,27 +1510,22 @@ static void X64_gen_instr(X64_Generator* generator, u32 live_regs, u32 instr_ind
         // Move addressing regs to temporary regs if necessary, emit div instruction, and then restore addressing regs.
         if (tmp_base_reg != X64_REG_COUNT) {
             assert(base_reg != X64_REG_COUNT);
-            X64_emit_text(generator, "    mov %s, %s", x64_reg_names[size][tmp_base_reg],
-                          x64_reg_names[size][base_reg]);
+            X64_emit_text(generator, "    mov %s, %s", x64_reg_names[size][tmp_base_reg], x64_reg_names[size][base_reg]);
         }
 
         if (tmp_index_reg != X64_REG_COUNT) {
             assert(index_reg != X64_REG_COUNT);
-            X64_emit_text(generator, "    mov %s, %s", x64_reg_names[size][tmp_index_reg],
-                          x64_reg_names[size][index_reg]);
+            X64_emit_text(generator, "    mov %s, %s", x64_reg_names[size][tmp_index_reg], x64_reg_names[size][index_reg]);
         }
 
-        X64_emit_div_instr(generator, instr_name, size, dst_loc,
-                           X64_print_sibd_addr(generator->tmp_mem, &src_addr, size), live_regs);
+        X64_emit_div_instr(generator, instr_name, size, dst_loc, X64_print_sibd_addr(generator->tmp_mem, &src_addr, size), live_regs);
 
         if (tmp_base_reg != X64_REG_COUNT) {
-            X64_emit_text(generator, "    mov %s, %s", x64_reg_names[size][base_reg],
-                          x64_reg_names[size][tmp_base_reg]);
+            X64_emit_text(generator, "    mov %s, %s", x64_reg_names[size][base_reg], x64_reg_names[size][tmp_base_reg]);
         }
 
         if (tmp_index_reg != X64_REG_COUNT) {
-            X64_emit_text(generator, "    mov %s, %s", x64_reg_names[size][index_reg],
-                          x64_reg_names[size][tmp_index_reg]);
+            X64_emit_text(generator, "    mov %s, %s", x64_reg_names[size][index_reg], x64_reg_names[size][tmp_index_reg]);
         }
 
         X64_end_reg_group(&src_tmp_group);
@@ -1576,8 +1552,7 @@ static void X64_gen_instr(X64_Generator* generator, u32 live_regs, u32 instr_ind
         X64_Reg imm_reg = X64_get_tmp_reg(&reg_group, banned_regs, live_regs);
         const char* src_op_str = x64_reg_names[size][imm_reg];
 
-        X64_emit_text(generator, "    mov %s, %s", src_op_str,
-                      X64_print_imm(generator->tmp_mem, instr->div_r_i.src, size));
+        X64_emit_text(generator, "    mov %s, %s", src_op_str, X64_print_imm(generator->tmp_mem, instr->div_r_i.src, size));
 
         X64_emit_div_instr(generator, instr_name, size, dst_loc, src_op_str, live_regs);
 
@@ -1596,20 +1571,18 @@ static void X64_gen_instr(X64_Generator* generator, u32 live_regs, u32 instr_ind
         bool src_in_reg = src_loc.kind == X64_VREG_LOC_REG;
 
         if (dst_in_reg && (dst_loc.reg == X64_RCX)) {
-            const char* src_swap_op_str =
-                src_in_reg ? x64_reg_names[X64_MAX_INT_REG_SIZE][src_loc.reg] :
-                             X64_print_stack_offset(generator->tmp_mem, src_loc.offset, X64_MAX_INT_REG_SIZE);
+            const char* src_swap_op_str = src_in_reg ?
+                                              x64_reg_names[X64_MAX_INT_REG_SIZE][src_loc.reg] :
+                                              X64_print_stack_offset(generator->tmp_mem, src_loc.offset, X64_MAX_INT_REG_SIZE);
             // NOTE: This intentially uses src's location and dst's size. Do not edit.
             const char* dst_op_str = src_in_reg ? x64_reg_names[dst_size][src_loc.reg] :
                                                   X64_print_stack_offset(generator->tmp_mem, src_loc.offset, dst_size);
 
-            X64_emit_text(generator, "    xchg %s, %s", x64_reg_names[X64_MAX_INT_REG_SIZE][dst_loc.reg],
-                          src_swap_op_str);
+            X64_emit_text(generator, "    xchg %s, %s", x64_reg_names[X64_MAX_INT_REG_SIZE][dst_loc.reg], src_swap_op_str);
 
             X64_emit_text(generator, "    sar %s, %s", dst_op_str, x64_reg_names[1][X64_RCX]);
 
-            X64_emit_text(generator, "    xchg %s, %s", x64_reg_names[X64_MAX_INT_REG_SIZE][dst_loc.reg],
-                          src_swap_op_str);
+            X64_emit_text(generator, "    xchg %s, %s", x64_reg_names[X64_MAX_INT_REG_SIZE][dst_loc.reg], src_swap_op_str);
         }
         else {
             bool src_in_rcx = src_in_reg && (src_loc.reg == X64_RCX);
@@ -1650,8 +1623,7 @@ static void X64_gen_instr(X64_Generator* generator, u32 live_regs, u32 instr_ind
             X64_emit_text(generator, "    xchg %s, %s", x64_reg_names[X64_MAX_INT_REG_SIZE][dst_loc.reg],
                           X64_print_sibd_addr(generator->tmp_mem, &addr, X64_MAX_INT_REG_SIZE));
 
-            X64_emit_text(generator, "    sar %s, %s", X64_print_sibd_addr(generator->tmp_mem, &addr, dst_size),
-                          cl_op_str);
+            X64_emit_text(generator, "    sar %s, %s", X64_print_sibd_addr(generator->tmp_mem, &addr, dst_size), cl_op_str);
 
             X64_emit_text(generator, "    xchg %s, %s", x64_reg_names[X64_MAX_INT_REG_SIZE][dst_loc.reg],
                           X64_print_sibd_addr(generator->tmp_mem, &addr, X64_MAX_INT_REG_SIZE));
@@ -1694,20 +1666,18 @@ static void X64_gen_instr(X64_Generator* generator, u32 live_regs, u32 instr_ind
         bool src_in_reg = src_loc.kind == X64_VREG_LOC_REG;
 
         if (dst_in_reg && (dst_loc.reg == X64_RCX)) {
-            const char* src_swap_op_str =
-                src_in_reg ? x64_reg_names[X64_MAX_INT_REG_SIZE][src_loc.reg] :
-                             X64_print_stack_offset(generator->tmp_mem, src_loc.offset, X64_MAX_INT_REG_SIZE);
+            const char* src_swap_op_str = src_in_reg ?
+                                              x64_reg_names[X64_MAX_INT_REG_SIZE][src_loc.reg] :
+                                              X64_print_stack_offset(generator->tmp_mem, src_loc.offset, X64_MAX_INT_REG_SIZE);
             // NOTE: This intentionally uses src's location and dst's size. Do not edit.
             const char* dst_op_str = src_in_reg ? x64_reg_names[dst_size][src_loc.reg] :
                                                   X64_print_stack_offset(generator->tmp_mem, src_loc.offset, dst_size);
 
-            X64_emit_text(generator, "    xchg %s, %s", x64_reg_names[X64_MAX_INT_REG_SIZE][dst_loc.reg],
-                          src_swap_op_str);
+            X64_emit_text(generator, "    xchg %s, %s", x64_reg_names[X64_MAX_INT_REG_SIZE][dst_loc.reg], src_swap_op_str);
 
             X64_emit_text(generator, "    shl %s, %s", dst_op_str, x64_reg_names[1][X64_RCX]);
 
-            X64_emit_text(generator, "    xchg %s, %s", x64_reg_names[X64_MAX_INT_REG_SIZE][dst_loc.reg],
-                          src_swap_op_str);
+            X64_emit_text(generator, "    xchg %s, %s", x64_reg_names[X64_MAX_INT_REG_SIZE][dst_loc.reg], src_swap_op_str);
         }
         else {
             bool src_in_rcx = src_in_reg && (src_loc.reg == X64_RCX);
@@ -1748,8 +1718,7 @@ static void X64_gen_instr(X64_Generator* generator, u32 live_regs, u32 instr_ind
             X64_emit_text(generator, "    xchg %s, %s", x64_reg_names[X64_MAX_INT_REG_SIZE][dst_loc.reg],
                           X64_print_sibd_addr(generator->tmp_mem, &addr, X64_MAX_INT_REG_SIZE));
 
-            X64_emit_text(generator, "    shl %s, %s", X64_print_sibd_addr(generator->tmp_mem, &addr, dst_size),
-                          cl_op_str);
+            X64_emit_text(generator, "    shl %s, %s", X64_print_sibd_addr(generator->tmp_mem, &addr, dst_size), cl_op_str);
 
             X64_emit_text(generator, "    xchg %s, %s", x64_reg_names[X64_MAX_INT_REG_SIZE][dst_loc.reg],
                           X64_print_sibd_addr(generator->tmp_mem, &addr, X64_MAX_INT_REG_SIZE));
@@ -1790,8 +1759,7 @@ static void X64_gen_instr(X64_Generator* generator, u32 live_regs, u32 instr_ind
         }
         else {
             assert(dst_loc.kind == X64_VREG_LOC_STACK);
-            X64_emit_text(generator, "    neg %s",
-                          X64_print_stack_offset(generator->tmp_mem, dst_loc.offset, (u32)type->size));
+            X64_emit_text(generator, "    neg %s", X64_print_stack_offset(generator->tmp_mem, dst_loc.offset, (u32)type->size));
         }
         break;
     }
@@ -1804,8 +1772,7 @@ static void X64_gen_instr(X64_Generator* generator, u32 live_regs, u32 instr_ind
         }
         else {
             assert(dst_loc.kind == X64_VREG_LOC_STACK);
-            X64_emit_text(generator, "    not %s",
-                          X64_print_stack_offset(generator->tmp_mem, dst_loc.offset, (u32)type->size));
+            X64_emit_text(generator, "    not %s", X64_print_stack_offset(generator->tmp_mem, dst_loc.offset, (u32)type->size));
         }
         break;
     }
@@ -1835,16 +1802,14 @@ static void X64_gen_instr(X64_Generator* generator, u32 live_regs, u32 instr_ind
         Type* dst_type = instr->zext_r_r.dst_type;
         Type* src_type = instr->zext_r_r.src_type;
 
-        X64_emit_rr_instr(generator, "movzx", true, dst_type->size, instr->zext_r_r.dst, src_type->size,
-                          instr->zext_r_r.src);
+        X64_emit_rr_instr(generator, "movzx", true, dst_type->size, instr->zext_r_r.dst, src_type->size, instr->zext_r_r.src);
         break;
     }
     case IR_INSTR_ZEXT_R_M: {
         Type* dst_type = instr->zext_r_m.dst_type;
         Type* src_type = instr->zext_r_m.src_type;
 
-        X64_emit_rm_instr(generator, "movzx", true, dst_type->size, instr->zext_r_m.dst, src_type->size,
-                          &instr->zext_r_m.src);
+        X64_emit_rm_instr(generator, "movzx", true, dst_type->size, instr->zext_r_m.dst, src_type->size, &instr->zext_r_m.src);
         break;
     }
     case IR_INSTR_SEXT_R_R: {
@@ -1852,8 +1817,7 @@ static void X64_gen_instr(X64_Generator* generator, u32 live_regs, u32 instr_ind
         Type* src_type = instr->sext_r_r.src_type;
         const char* movsx = src_type->size >= builtin_types[BUILTIN_TYPE_U32].type->size ? "movsxd" : "movsx";
 
-        X64_emit_rr_instr(generator, movsx, true, dst_type->size, instr->sext_r_r.dst, src_type->size,
-                          instr->sext_r_r.src);
+        X64_emit_rr_instr(generator, movsx, true, dst_type->size, instr->sext_r_r.dst, src_type->size, instr->sext_r_r.src);
         break;
     }
     case IR_INSTR_SEXT_R_M: {
@@ -1861,8 +1825,7 @@ static void X64_gen_instr(X64_Generator* generator, u32 live_regs, u32 instr_ind
         Type* src_type = instr->sext_r_m.src_type;
         const char* movsx = src_type->size >= builtin_types[BUILTIN_TYPE_U32].type->size ? "movsxd" : "movsx";
 
-        X64_emit_rm_instr(generator, movsx, true, dst_type->size, instr->sext_r_m.dst, src_type->size,
-                          &instr->sext_r_m.src);
+        X64_emit_rm_instr(generator, movsx, true, dst_type->size, instr->sext_r_m.dst, src_type->size, &instr->sext_r_m.src);
         break;
     }
     case IR_INSTR_LOAD: {
@@ -1926,8 +1889,7 @@ static void X64_gen_instr(X64_Generator* generator, u32 live_regs, u32 instr_ind
         X64_VRegLoc dst_loc = X64_vreg_loc(generator, instr->setcc.dst);
 
         if (dst_loc.kind == X64_VREG_LOC_REG) {
-            X64_emit_text(generator, "    set%s %s", x64_condition_codes[instr->setcc.cond],
-                          x64_reg_names[1][dst_loc.reg]);
+            X64_emit_text(generator, "    set%s %s", x64_condition_codes[instr->setcc.cond], x64_reg_names[1][dst_loc.reg]);
         }
         else {
             assert(dst_loc.kind == X64_VREG_LOC_STACK);
@@ -1955,8 +1917,7 @@ static void X64_gen_instr(X64_Generator* generator, u32 live_regs, u32 instr_ind
         }
 
         if (!is_last_instr)
-            X64_emit_text(generator, "    jmp end.%s",
-                          symbol_mangled_name(generator->tmp_mem, generator->curr_proc.sym));
+            X64_emit_text(generator, "    jmp end.%s", symbol_mangled_name(generator->tmp_mem, generator->curr_proc.sym));
 
         break;
     }
@@ -2008,8 +1969,7 @@ static void X64_gen_instr(X64_Generator* generator, u32 live_regs, u32 instr_ind
         //   - |arg_info_map| maps an x64 register to the arg_info element that currently occupies it.
         X64_ArgInfo* arg_infos = alloc_array(generator->tmp_mem, X64_ArgInfo, num_args, true);
         X64_ArgInfo* arg_info_map[X64_REG_COUNT] = {0};
-        X64_StackArgsInfo stack_args_info =
-            X64_preprocess_call_args(generator, live_regs, num_args, args, arg_infos, arg_info_map);
+        X64_StackArgsInfo stack_args_info = X64_preprocess_call_args(generator, live_regs, num_args, args, arg_infos, arg_info_map);
 
         // Place arguments in the appropriate locations.
         X64_place_args_in_regs(&group, num_args, arg_infos,
@@ -2036,8 +1996,8 @@ static void X64_gen_instr(X64_Generator* generator, u32 live_regs, u32 instr_ind
         else {
             X64_VRegLoc proc_reg_loc = X64_vreg_loc(generator, instr->call_r.proc_loc);
             const char* call_op_str = proc_reg_loc.kind == X64_VREG_LOC_REG ?
-                x64_reg_names[PTR_SIZE][proc_reg_loc.reg] :
-                X64_print_stack_offset(generator->tmp_mem, proc_reg_loc.offset, PTR_SIZE);
+                                          x64_reg_names[PTR_SIZE][proc_reg_loc.reg] :
+                                          X64_print_stack_offset(generator->tmp_mem, proc_reg_loc.offset, PTR_SIZE);
 
             X64_emit_text(generator, "    call %s", call_op_str);
         }
@@ -2050,8 +2010,7 @@ static void X64_gen_instr(X64_Generator* generator, u32 live_regs, u32 instr_ind
 
             if (dst_loc.kind == X64_VREG_LOC_STACK) {
                 // Move result (in RAX) to stack offset.
-                X64_emit_text(generator, "    mov %s, %s",
-                              X64_print_stack_offset(generator->tmp_mem, dst_loc.offset, ret_type->size),
+                X64_emit_text(generator, "    mov %s, %s", X64_print_stack_offset(generator->tmp_mem, dst_loc.offset, ret_type->size),
                               x64_reg_names[ret_type->size][X64_RAX]);
             }
             else {
@@ -2132,8 +2091,8 @@ static void X64_gen_proc(X64_Generator* generator, u32 proc_id, Symbol* sym)
     X64_VRegLoc* vreg_locs = alloc_array(generator->tmp_mem, X64_VRegLoc, num_vregs, true);
 
     X64_RegAllocResult reg_alloc =
-        X64_linear_scan_reg_alloc(generator->tmp_mem, num_vregs, vreg_intervals, vreg_locs,
-                                  generator->curr_proc.num_scratch_regs, generator->curr_proc.scratch_regs, stack_size);
+        X64_linear_scan_reg_alloc(generator->tmp_mem, num_vregs, vreg_intervals, vreg_locs, generator->curr_proc.num_scratch_regs,
+                                  generator->curr_proc.scratch_regs, stack_size);
 
     stack_size = reg_alloc.stack_offset;
     generator->curr_proc.vreg_map = vreg_locs;

--- a/src/x64_gen/gen.c
+++ b/src/x64_gen/gen.c
@@ -319,6 +319,19 @@ static void X64_print_global_arr_elem(Allocator* allocator, Expr* elem, char** l
         X64_print_global_arr_init(allocator, (ExprCompoundLit*)elem, line, end_sep);
         break;
     }
+    case CST_ExprStr: {
+        StrLit* str_lit = ((ExprStr*)elem)->str_lit;
+        size_t len = str_lit->len;
+        const char* str = str_lit->str;
+
+        for (size_t i = 0; i < len; i += 1) {
+            ftprint_char_array(line, false, "0x%.2X,", str[i]);
+        }
+
+        ftprint_char_array(line, false, "0x00%c", end_sep);
+
+        break;
+    }
     default:
         assert(0);
         break;

--- a/tests/2d_array.nib
+++ b/tests/2d_array.nib
@@ -1,6 +1,9 @@
-var g_a : []int = {1,2,3,[5]=4};
-var g_b : [][2]int = {
+var g_a : [][2]int = {
     {0, 1}, {2, 3}
+};
+
+var g_b : [2][3]char = {
+    "cc", {'d', 'd'}
 };
 
 proc main() => int {
@@ -16,6 +19,10 @@ proc main() => int {
 
     #writeout(b[1], 2);
     #writeout("\n", 1);
+    #writeout(g_b[0], 2);
+    #writeout("\n", 1);
+    #writeout(g_b[1], 2);
+    #writeout("\n", 1);
 
-    return a[1][1] + g_a[5] + g_b[1][0]; // 3 + 4 + 2 = 9
+    return a[1][1] + g_a[1][0]; // 3 + 2 = 5
 }

--- a/tests/2d_array.nib
+++ b/tests/2d_array.nib
@@ -6,6 +6,10 @@ var g_b : [2][3]char = {
     "cc", {'d', 'd'}
 };
 
+var g_c : [2]^char = {
+    "ee", "ff"
+};
+
 proc main() => int {
     var a : [2][2]int = {
         {0, 1},
@@ -17,12 +21,16 @@ proc main() => int {
         "bb"
     };
 
+    var nl : char = '\n';
+
     #writeout(b[1], 2);
     #writeout("\n", 1);
     #writeout(g_b[0], 2);
     #writeout("\n", 1);
     #writeout(g_b[1], 2);
     #writeout("\n", 1);
+    #writeout(g_c[1], 2);
+    #writeout(^nl, 1);
 
     return a[1][1] + g_a[1][0]; // 3 + 2 = 5
 }

--- a/tests/2d_array.nib
+++ b/tests/2d_array.nib
@@ -1,3 +1,7 @@
+var g_a : []int = {1,2,3,[5]=4};
+var g_b : [][2]int = {
+    {0, 1}, {2, 3}
+};
 
 proc main() => int {
     var a : [2][2]int = {
@@ -13,5 +17,5 @@ proc main() => int {
     #writeout(b[1], 2);
     #writeout("\n", 1);
 
-    return a[1][1];
+    return a[1][1] + g_a[5] + g_b[1][0]; // 3 + 4 + 2 = 9
 }

--- a/tests/globals.nib
+++ b/tests/globals.nib
@@ -1,0 +1,47 @@
+var g_a : [][2]int = {
+    {0, 1}, {2, 3}
+};
+
+var g_b : [2][3]char = {
+    "cc", {'d', 'd'}
+};
+
+var g_c : [4]^char = {
+    "ee", "ff", (0xdeadbeef :> ^char), ^g_ch
+};
+
+var g_d : []char = "copy\n";
+
+var g_ch : char = 'g';
+var g_str : ^char = "global\n";
+//var g_str_off : ^char = ^g_str[1]; // Not allowed. Equivalent to ^*(g_str + 1);
+
+var g_p_var : ^^char = ^g_str;
+var g_p_imm : ^char = 0xdeadbeef :> ^char;
+
+proc main() => int {
+    var nl : char = '\n';
+
+    #writeout(g_b[0], 2);
+    #writeout("\n", 1);
+    #writeout(g_b[1], 2);
+    #writeout("\n", 1);
+    #writeout(g_c[0], 2);
+    #writeout(^nl, 1);
+    #writeout(g_c[1], 2);
+    #writeout(^nl, 1);
+    #writeout(g_c[3], 1);
+    #writeout(^nl, 1);
+
+    #writeout(g_str, 7);
+    #writeout(*g_p_var, 7);
+
+    // Print out g_d (contains copy of str lit)
+    #writeout(g_d, 5);
+
+    // Modify g_d and then print again
+    g_d[0] = 'k';
+    #writeout(g_d, 5);
+
+    return g_a[1][0]; // 2
+}

--- a/tests/str_lit.nib
+++ b/tests/str_lit.nib
@@ -9,7 +9,7 @@ proc first_char(str: ^char) => char {
 
 proc main() => int
 {
-    var a : ^char = "Hello";
+    var a : ^char = "Hello\n";
 
     //"Hello"[1] = 'Z'; // Segfaults because literals are stored in readonly memory.
 
@@ -19,7 +19,12 @@ proc main() => int
     //var t : [6]char;
     //t = "12345";
 
-    #writeout(a, 6);
+    #writeout(a, 7);
+
+    var p : ^char = "hi\n";
+    var pp : ^^char = ^p;
+
+    #writeout(*pp + 1, 2);
 
     // 'S' + 'e' - '5' + 'E' - 0 - '4' <=> 83 + 101 - 53 + 69 - 0 - 52 = 148
     return first_char("Sailor\n`") + a[1] - s[4] + g_s[1] - g_a[2] - g_b[2]; 


### PR DESCRIPTION
```c
var g_a : [][2]int = {
    {0, 1}, {2, 3}
};

var g_b : [2][3]char = {
    "cc", {'d', 'd'}
};

var g_c : [4]^char = {
    "ee", "ff", (0xdeadbeef :> ^char), ^g_ch
};

var g_d : []char = "copy\n";

var g_ch : char = 'g';
var g_str : ^char = "global\n";
//var g_str_off : ^char = ^g_str[1]; // Not allowed. Equivalent to ^*(g_str + 1);

var g_p_var : ^^char = ^g_str;
var g_p_imm : ^char = 0xdeadbeef :> ^char;
```