### PR TITLE
Generate bytecode and x64 asm for break and continue statements

### DIFF
--- a/src/bytecode.h
+++ b/src/bytecode.h
@@ -264,12 +264,12 @@ typedef enum IR_ConditionKind {
 } IR_ConditionKind;
 
 typedef struct IR_InstrJmpCC {
-    u32 jmp_target;
+    u32* jmp_target;
     IR_ConditionKind cond;
 } IR_InstrJmpCC;
 
 typedef struct IR_InstrJmp {
-    u32 jmp_target;
+    u32* jmp_target;
 } IR_InstrJmp;
 
 typedef struct IR_InstrSetCC {

--- a/src/bytecode/procs.c
+++ b/src/bytecode/procs.c
@@ -2454,15 +2454,6 @@ static void IR_emit_stmt_while(IR_ProcBuilder* builder, StmtWhile* stmt)
         IR_emit_expr(builder, cond_expr, &cond_op);
 
         if (cond_op.kind == IR_OPERAND_DEFERRED_CMP) {
-            u32 loop_bottom = IR_get_jmp_target(builder);
-
-            // Patch short-circuit jumps to the top or bottom of the loop.
-            for (IR_DeferredJmpcc* it = cond_op.cmp.first_sc_jmp; it; it = it->next) {
-                if (it->result)
-                    IR_patch_jmp_target(it->jmp, loop_top);
-                else
-                    IR_patch_jmp_target(it->jmp, loop_bottom);
-            }
 
             // Path final jump to the top of the loop (create one if jump does not exist).
             if (cond_op.cmp.final_jmp.jmp)
@@ -2473,6 +2464,16 @@ static void IR_emit_stmt_while(IR_ProcBuilder* builder, StmtWhile* stmt)
             // Reverse jump condition so that it goes to the "true" path.
             if (!cond_op.cmp.final_jmp.result)
                 cond_op.cmp.final_jmp.jmp->jmpcc.cond = ir_opposite_cond[cond_op.cmp.final_jmp.cond];
+
+            u32 loop_bottom = IR_get_jmp_target(builder);
+
+            // Patch short-circuit jumps to the top or bottom of the loop.
+            for (IR_DeferredJmpcc* it = cond_op.cmp.first_sc_jmp; it; it = it->next) {
+                if (it->result)
+                    IR_patch_jmp_target(it->jmp, loop_top);
+                else
+                    IR_patch_jmp_target(it->jmp, loop_bottom);
+            }
         }
         else {
             IR_op_to_r(builder, &cond_op, true);
@@ -2521,15 +2522,6 @@ static void IR_emit_stmt_do_while(IR_ProcBuilder* builder, StmtDoWhile* stmt)
         IR_emit_expr(builder, cond_expr, &cond_op);
 
         if (cond_op.kind == IR_OPERAND_DEFERRED_CMP) {
-            u32 loop_bottom = IR_get_jmp_target(builder);
-
-            // Patch short-circuit jumps to the top or bottom of the loop.
-            for (IR_DeferredJmpcc* it = cond_op.cmp.first_sc_jmp; it; it = it->next) {
-                if (it->result)
-                    IR_patch_jmp_target(it->jmp, loop_top);
-                else
-                    IR_patch_jmp_target(it->jmp, loop_bottom);
-            }
 
             // Path final jump to the top of the loop (create one if jump does not exist).
             if (cond_op.cmp.final_jmp.jmp)
@@ -2540,6 +2532,16 @@ static void IR_emit_stmt_do_while(IR_ProcBuilder* builder, StmtDoWhile* stmt)
             // Reverse jump condition so that it goes to the "true" path.
             if (!cond_op.cmp.final_jmp.result)
                 cond_op.cmp.final_jmp.jmp->jmpcc.cond = ir_opposite_cond[cond_op.cmp.final_jmp.cond];
+
+            u32 loop_bottom = IR_get_jmp_target(builder);
+
+            // Patch short-circuit jumps to the top or bottom of the loop.
+            for (IR_DeferredJmpcc* it = cond_op.cmp.first_sc_jmp; it; it = it->next) {
+                if (it->result)
+                    IR_patch_jmp_target(it->jmp, loop_top);
+                else
+                    IR_patch_jmp_target(it->jmp, loop_bottom);
+            }
         }
         else {
             IR_op_to_r(builder, &cond_op, true);

--- a/src/x64_gen/gen.c
+++ b/src/x64_gen/gen.c
@@ -1820,12 +1820,12 @@ static void X64_gen_instr(X64_Generator* generator, u32 live_regs, u32 instr_ind
         break;
     }
     case IR_INSTR_JMP: {
-        X64_emit_text(generator, "    jmp %s", X64_get_label(generator, instr->jmp.jmp_target));
+        X64_emit_text(generator, "    jmp %s", X64_get_label(generator, *instr->jmp.jmp_target));
         break;
     }
     case IR_INSTR_JMPCC: {
         X64_emit_text(generator, "    j%s %s", x64_condition_codes[instr->jmpcc.cond],
-                      X64_get_label(generator, instr->jmpcc.jmp_target));
+                      X64_get_label(generator, *instr->jmpcc.jmp_target));
         break;
     }
     case IR_INSTR_SETCC: {

--- a/tests/break.nib
+++ b/tests/break.nib
@@ -1,0 +1,48 @@
+
+proc main() => int {
+    var i := 0;
+    var j := 0;
+    var k := 0;
+
+    // Infinite loop
+    while (1) {
+        i = i + 1;
+
+        if (i == 10) {
+            break;
+        }
+        if (i >= 10) {
+            i = 0; // Should not execute
+        }
+    }
+
+    // While loop
+    while (j < 20) {
+        j = j + 1;
+
+        if (j == 10) {
+            break;
+        }
+
+        if (j >= 10) {
+            j = 0; // Should not execute
+        }
+    }
+
+    // Do-while loop
+    do {
+        k = k + 1;
+
+        if (k > 9) {
+            break;
+        }
+
+        if (k >= 10) {
+            k = 0; // Should not execute
+        }
+    } while (k < 20);
+
+    // TODO: for loop
+
+    return i + j + k; // 10 + 10 + 10 = 30
+}

--- a/tests/continue.nib
+++ b/tests/continue.nib
@@ -1,0 +1,85 @@
+
+proc main() => int {
+    var i := 0;
+    var j := 0;
+    var k := 0;
+    var z := 0;
+
+    // Infinite loop
+    // Sum odd numbers up to 10
+    while (1) {
+        if (i > 10) break;
+
+        var rem := i - (i / 2)*2;
+
+        if (rem == 0) {
+            i = i + 1;
+            continue;
+        }
+
+        j = j + i;
+
+        i = i + 1;
+    }
+
+    // While loop
+    // Add even numbers up to 10
+    i = 0;
+    while (i <= 10) {
+        var rem := i - (i / 2)*2;
+
+        if (rem == 1) {
+            i = i + 1;
+            continue;
+        }
+
+        k = k + i;
+
+        i = i + 1;
+    }
+
+    // Do-while loop
+    // Add evens up to 10
+    i = 0;
+    do {
+        var rem := i - (i / 2)*2;
+
+        if (rem == 1) {
+            i = i + 1;
+            continue;
+        }
+
+        z = z + i;
+
+        i = i + 1;
+    } while (i <= 10);
+
+    // Nested loops
+    // Sum is 14
+    i = 0;
+    var ii := 0;
+    var sum :=0;
+    while (i < 4) {
+        sum = sum + i; // Outer is 0, 1, 2, 3
+
+        ii = 0;
+        while (ii < 4) {
+            var rem := ii - (ii / 2)*2;
+
+            if (rem == 1) { // Skip odd ii
+                ii = ii + 1;
+                continue;
+            }
+
+            sum = sum + ii; // Inner is 0, 2
+
+            ii = ii + 1;
+        }
+
+        i = i + 1;
+    }
+
+    // TODO: for loop
+
+    return j + k + z + sum; // 25 + 30 + 30 + 14 = 99
+}


### PR DESCRIPTION
As it says on the tin. This only implements basic `break` and `continue` statements as they exist in C. Labeled break/continue will come later.