### PR TITLE
Zero-initialize variables by default

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,6 +9,7 @@ A programming language based on C. The goal is to create a compiled, statically-
 - [x] Multiple return values (return anonymous structure object aka tuples)
 - [x] Type-safe variadic procedures
 - [x] Array slices (See [C's Biggest Mistake](https://digitalmars.com/articles/C-biggest-mistake.html))
+- [x] Variables initialized to zero by default (use `---` value to leave uninitialized)
 - [ ] Defer statement (like go)
 - [ ] Default procedure arguments
 - [ ] Named procedure arguments

--- a/src/bytecode/vars.c
+++ b/src/bytecode/vars.c
@@ -209,7 +209,7 @@ static void IR_emit_global_expr_array_lit(IR_VarBuilder* builder, ExprCompoundLi
 static void IR_emit_global_expr_struct_lit(IR_VarBuilder* builder, ExprCompoundLit* expr, ConstExpr* dst)
 {
     Type* type = expr->super.type;
-    TypeAggregate* type_agg = &type->as_aggregate;
+    TypeAggregateBody* type_agg = &type->as_struct.body;
     TypeAggregateField* fields = type_agg->fields;
     size_t num_fields = type_agg->num_fields;
 
@@ -227,7 +227,7 @@ static void IR_emit_global_expr_struct_lit(IR_VarBuilder* builder, ExprCompoundL
         TypeAggregateField* field;
 
         if (initzer->designator.kind == DESIGNATOR_NAME) {
-            field = get_type_aggregate_field(type, initzer->designator.name);
+            field = get_type_struct_field(type, initzer->designator.name);
             assert(field);
 
             field_index = field->index + 1;
@@ -268,7 +268,7 @@ static void IR_emit_global_expr_union_lit(IR_VarBuilder* builder, ExprCompoundLi
         MemberInitializer* initzer = list_entry(it, MemberInitializer, lnode);
 
         if (initzer->designator.kind == DESIGNATOR_NAME) {
-            TypeAggregateField* field = get_type_aggregate_field(type, initzer->designator.name);
+            TypeAggregateField* field = get_type_union_field(type, initzer->designator.name);
             assert(field);
 
             field_index = field->index;

--- a/src/lexer.c
+++ b/src/lexer.c
@@ -494,6 +494,7 @@ const char* token_kind_names[] = {
     [TKN_COMMA] = ",",
     [TKN_DOT] = ".",
     [TKN_ELLIPSIS] = "..",
+    [TKN_UNINIT] = "---",
     [TKN_ARROW] = "=>",
     [TKN_CAST] = ":>",
     [TKN_AT] = "@",
@@ -673,6 +674,10 @@ top:
         if (lexer->at[0] == '=') {
             lexer->at++;
             token.kind = TKN_SUB_ASSIGN;
+        }
+        else if (lexer->at[0] == '-' && lexer->at[1] == '-') { // NOTE: Prevents negating three times in a row.
+            lexer->at += 2;
+            token.kind = TKN_UNINIT;
         }
 
         break;

--- a/src/lexer.h
+++ b/src/lexer.h
@@ -21,6 +21,7 @@ typedef enum TokenKind {
     TKN_COMMA,
     TKN_DOT,
     TKN_ELLIPSIS,
+    TKN_UNINIT,
     TKN_ARROW,
     TKN_CAST,
     TKN_AT,

--- a/src/x64_gen/gen.c
+++ b/src/x64_gen/gen.c
@@ -271,7 +271,7 @@ static void X64_print_global_struct_init(Allocator* allocator, ConstExpr* const_
     Type* type = const_expr->type;
     assert(type->kind == TYPE_STRUCT);
 
-    TypeAggregate* type_agg = &type->as_aggregate;
+    TypeAggregateBody* type_agg = &type->as_struct.body;
     ConstExpr** field_exprs = const_expr->struct_initzer.field_exprs;
 
     TypeAggregateField* fields = type_agg->fields;
@@ -314,7 +314,7 @@ static void X64_print_global_union_init(Allocator* allocator, ConstExpr* const_e
     Type* type = const_expr->type;
     assert(type->kind == TYPE_UNION);
 
-    TypeAggregateField* field = &type->as_aggregate.fields[const_expr->union_initzer.field_index];
+    TypeAggregateField* field = &type->as_union.body.fields[const_expr->union_initzer.field_index];
     ConstExpr* field_expr = const_expr->union_initzer.field_expr;
 
     if (field_expr) {

--- a/tests/uninit.nib
+++ b/tests/uninit.nib
@@ -28,7 +28,9 @@ proc uninit_union() {
 }
 
 proc main() => int {
-    var a : int = ---;
+    var a : int = ---; // Explicitly uninitialized!!!
+
+    // Implicitly initialized to zero:
     var b : int;
     var vec : Vec3;
     var arr : [3]int;
@@ -38,3 +40,4 @@ proc main() => int {
     // 0 due to automatic zero initialization.
     return b + (vec.x + vec.y + vec.z) + (arr[0] + arr[1] + arr[2]) + lrg[1023] + uni._s64;
 }
+

--- a/tests/uninit.nib
+++ b/tests/uninit.nib
@@ -15,6 +15,17 @@ union Value {
     _s64: s64;
 }
 
+proc uninit_arr() {
+    var arr : [1024]int = ---;
+}
+
+proc uninit_struct() {
+    var s : Vec3 = ---;
+}
+
+proc uninit_union() {
+    var u : Value = ---;
+}
 
 proc main() => int {
     var a : int = ---;

--- a/tests/uninit.nib
+++ b/tests/uninit.nib
@@ -1,0 +1,29 @@
+struct Vec3 {
+    x : int;
+    y : int;
+    z : int;
+}
+
+union Value {
+    _u8: u8;
+    _s8: s8;
+    _u16: u16;
+    _s16: s16;
+    _u32: u32;
+    _s32: s32;
+    _u64: u64;
+    _s64: s64;
+}
+
+
+proc main() => int {
+    var a : int = ---;
+    var b : int;
+    var vec : Vec3;
+    var arr : [3]int;
+    var lrg : [1024]char;
+    var uni : Value;
+
+    // 0 due to automatic zero initialization.
+    return b + (vec.x + vec.y + vec.z) + (arr[0] + arr[1] + arr[2]) + lrg[1023] + uni._s64;
+}


### PR DESCRIPTION
```c
struct Vec3 {
    x : int;
    y : int;
    z : int;
}

union Value {
    _u8: u8;
    _s8: s8;
    _u16: u16;
    _s16: s16;
    _u32: u32;
    _s32: s32;
    _u64: u64;
    _s64: s64;
}

proc uninit_arr() {
    var arr : [1024]int = ---;
}

proc uninit_struct() {
    var s : Vec3 = ---;
}

proc uninit_union() {
    var u : Value = ---;
}

proc main() => int {
    var a : int = ---; // Explicitly uninitialized!!!

    // Implicitly initialized to zero:
    var b : int;
    var vec : Vec3;
    var arr : [3]int;
    var lrg : [1024]char;
    var uni : Value;

    // 0 due to automatic zero initialization.
    return b + (vec.x + vec.y + vec.z) + (arr[0] + arr[1] + arr[2]) + lrg[1023] + uni._s64;
}
```