### PR TITLE
Add comptime #ret_type

### DIFF
--- a/src/ast.c
+++ b/src/ast.c
@@ -31,6 +31,14 @@ TypeSpec* new_typespec_typeof(Allocator* allocator, Expr* expr, ProgRange range)
     return (TypeSpec*)typespec;
 }
 
+TypeSpec* new_typespec_ret_type(Allocator* allocator, Expr* proc_expr, ProgRange range)
+{
+    TypeSpecRetType* ts = new_typespec(allocator, TypeSpecRetType, range);
+    ts->proc_expr = proc_expr;
+
+    return (TypeSpec*)ts;
+}
+
 TypeSpec* new_typespec_ptr(Allocator* allocator, TypeSpec* base, ProgRange range)
 {
     TypeSpecPtr* typespec = new_typespec(allocator, TypeSpecPtr, range);

--- a/src/ast.h
+++ b/src/ast.h
@@ -60,6 +60,7 @@ typedef enum TypeSpecKind {
     CST_TypeSpecArray,
     CST_TypeSpecConst,
     CST_TypeSpecTypeof,
+    CST_TypeSpecRetType,
 } TypeSpecKind;
 
 struct TypeSpec {
@@ -76,6 +77,11 @@ typedef struct TypeSpecTypeof {
     TypeSpec super;
     Expr* expr;
 } TypeSpecTypeof;
+
+typedef struct TypeSpecRetType {
+    TypeSpec super;
+    Expr* proc_expr;
+} TypeSpecRetType;
 
 typedef struct AggregateField {
     ProgRange range;
@@ -129,6 +135,7 @@ AggregateField* new_aggregate_field(Allocator* allocator, Identifier* name, Type
 
 TypeSpec* new_typespec_ident(Allocator* allocator, NSIdent* ns_ident);
 TypeSpec* new_typespec_typeof(Allocator* allocator, Expr* expr, ProgRange range);
+TypeSpec* new_typespec_ret_type(Allocator* allocator, Expr* proc_expr, ProgRange range);
 TypeSpec* new_typespec_ptr(Allocator* allocator, TypeSpec* base, ProgRange range);
 TypeSpec* new_typespec_array(Allocator* allocator, TypeSpec* base, Expr* len, bool infer_len, ProgRange range);
 TypeSpec* new_typespec_const(Allocator* allocator, TypeSpec* base, ProgRange range);

--- a/src/nibble.c
+++ b/src/nibble.c
@@ -399,6 +399,7 @@ static bool init_keywords()
         [KW_OFFSETOF] = string_view_lit("#offsetof"),
         [KW_LENGTH] = string_view_lit("#length"),
         [KW_STATIC_ASSERT] = string_view_lit("#static_assert"),
+        [KW_RET_TYPE] = string_view_lit("#ret_type"),
         [KW_EXPORT] = string_view_lit("export"),
         [KW_IMPORT] = string_view_lit("import"),
         [KW_FROM] = string_view_lit("from"),

--- a/src/nibble.h
+++ b/src/nibble.h
@@ -135,6 +135,7 @@ typedef enum Keyword {
     KW_OFFSETOF,
     KW_LENGTH,
     KW_STATIC_ASSERT,
+    KW_RET_TYPE,
     KW_EXPORT,
     KW_IMPORT,
     KW_FROM,

--- a/src/resolver.c
+++ b/src/resolver.c
@@ -26,7 +26,6 @@ static bool resolve_decl_var(Resolver* resolver, Symbol* sym);
 static bool resolve_decl_const(Resolver* resolver, Symbol* sym);
 static bool resolve_decl_proc(Resolver* resolver, Symbol* sym);
 static bool resolve_global_proc_body(Resolver* resolver, Symbol* sym);
-static bool resolve_proc_stmts(Resolver* resolver, Symbol* sym);
 
 typedef struct CastResult {
     bool success;
@@ -82,6 +81,9 @@ static void set_scope(Resolver* resolver, Scope* scope);
 static Scope* push_scope(Resolver* resolver, size_t num_syms);
 static void pop_scope(Resolver* resolver);
 
+static ModuleState enter_proc(Resolver* resolver, Symbol* sym);
+static void exit_proc(Resolver* resolver, ModuleState state);
+
 static void resolver_on_error(Resolver* resolver, ProgRange range, const char* format, ...)
 {
     char buf[MAX_ERROR_LEN];
@@ -115,6 +117,7 @@ static ModuleState enter_module(Resolver* resolver, Module* mod)
     ModuleState old_state = resolver->state;
 
     resolver->state.mod = mod;
+    resolver->state.proc = NULL;
     resolver->state.scope = &mod->scope;
 
     return old_state;
@@ -146,6 +149,26 @@ static Scope* push_scope(Resolver* resolver, size_t num_syms)
 static void pop_scope(Resolver* resolver)
 {
     resolver->state.scope = resolver->state.scope->parent;
+}
+
+static ModuleState enter_proc(Resolver* resolver, Symbol* sym)
+{
+    assert(sym->kind == SYMBOL_PROC);
+    ModuleState mod_state = enter_module(resolver, sym->home);
+
+    DeclProc* dproc = (DeclProc*)(sym->decl);
+    set_scope(resolver, dproc->scope);
+
+    resolver->state.proc = sym;
+
+    return mod_state;
+}
+
+static void exit_proc(Resolver* resolver, ModuleState state)
+{
+    pop_scope(resolver);
+    resolver->state.proc = NULL;
+    exit_module(resolver, state);
 }
 
 #define CASE_INT_CAST(k, o, t, f)                      \
@@ -2574,6 +2597,20 @@ static Type* resolve_typespec(Resolver* resolver, TypeSpec* typespec)
 
         return ts->expr->type;
     }
+    case CST_TypeSpecRetType: {
+        TypeSpecRetType* ts = (TypeSpecRetType*)typespec;
+
+        Type* proc_type = NULL;
+
+        if (ts->proc_expr) {
+            // TODO: Get proc type from expression.
+        }
+        else {
+            // TODO: Get proc type from current procedure
+        }
+
+        return proc_type->as_proc.ret;
+    }
     case CST_TypeSpecPtr: {
         TypeSpecPtr* ts = (TypeSpecPtr*)typespec;
         TypeSpec* base_ts = ts->base;
@@ -3132,33 +3169,6 @@ static bool resolve_decl_proc(Resolver* resolver, Symbol* sym)
     return true;
 }
 
-static bool resolve_proc_stmts(Resolver* resolver, Symbol* sym)
-{
-    assert(sym->kind == SYMBOL_PROC);
-
-    DeclProc* dproc = (DeclProc*)(sym->decl);
-
-    set_scope(resolver, dproc->scope);
-
-    Type* ret_type = sym->type->as_proc.ret;
-    unsigned r = resolve_stmt_block_body(resolver, &dproc->stmts, ret_type, 0);
-    bool returns = r & RESOLVE_STMT_RETURNS;
-    bool success = r & RESOLVE_STMT_SUCCESS;
-
-    assert(!success || !(r & RESOLVE_STMT_LOOP_EXITS));
-
-    pop_scope(resolver);
-
-    dproc->returns = returns;
-
-    if ((ret_type != builtin_types[BUILTIN_TYPE_VOID].type) && !returns && success) {
-        resolver_on_error(resolver, dproc->super.range, "Not all code paths in procedure `%s` return a value", dproc->super.name->str);
-        return false;
-    }
-
-    return success;
-}
-
 static bool resolve_global_proc_body(Resolver* resolver, Symbol* sym)
 {
     assert(sym->kind == SYMBOL_PROC);
@@ -3168,30 +3178,25 @@ static bool resolve_global_proc_body(Resolver* resolver, Symbol* sym)
         return true;
     }
 
-    ModuleState mod_state = enter_module(resolver, sym->home);
-    bool success = resolve_proc_stmts(resolver, sym);
+    ModuleState mod_state = enter_proc(resolver, sym);
 
-    exit_module(resolver, mod_state);
+    Type* ret_type = sym->type->as_proc.ret;
+    unsigned r = resolve_stmt_block_body(resolver, &dproc->stmts, ret_type, 0);
+    bool returns = r & RESOLVE_STMT_RETURNS;
+    bool success = r & RESOLVE_STMT_SUCCESS;
+
+    assert(!success || !(r & RESOLVE_STMT_LOOP_EXITS));
+
+    dproc->returns = returns;
+
+    if ((ret_type != builtin_types[BUILTIN_TYPE_VOID].type) && !returns && success) {
+        resolver_on_error(resolver, dproc->super.range, "Not all code paths in procedure `%s` return a value", dproc->super.name->str);
+        return false;
+    }
+
+    exit_proc(resolver, mod_state);
 
     return success;
-
-    // TODO: Support local struct/union/enum declarations inside procedures.
-    /*
-    while (array_len(resolver->incomplete_syms))
-    {
-        Symbol* sym = array_pop(resolver->incomplete_syms);
-
-        if (sym->kind == SYMBOL_PROC)
-        {
-            push_ir_proc(resolver, sym);
-
-            if (!resolve_proc_stmts(resolver, sym))
-                return false;
-        }
-    }
-    */
-
-    return true;
 }
 
 static unsigned resolve_stmt_block_body(Resolver* resolver, List* stmts, Type* ret_type, unsigned flags)

--- a/src/resolver.h
+++ b/src/resolver.h
@@ -6,6 +6,7 @@
 
 typedef struct ModuleState {
     Module* mod;
+    Symbol* proc;
     Scope* scope;
 } ModuleState;
 

--- a/tests/ret_type.nib
+++ b/tests/ret_type.nib
@@ -1,0 +1,20 @@
+proc vec3(x: int, y: int, z: int) => {int; int; int} {
+    var v : #ret_type = {x, y, z};
+
+    return v;
+}
+
+// Will not compile: #ret_type (without arg) must be used inside a procedure.
+//var inv : #ret_type = 10;
+
+proc main() => int {
+    var v : #ret_type(vec3) = vec3(1, 2, 3); // Equivalent to var v := vec3(1,2,3);
+    #static_assert(#typeid(#typeof(v)) == #typeid({int; int; int;}));
+
+    // Will not compile: variable `not_a_proc` is not a procedure.
+    //var not_a_proc : int = 2;
+    //var v2 : #ret_type(not_a_proc) = 10;
+
+    // 1 + 2 + 3 = 6
+    return v.[0] + v.[1] + v.[2];
+}


### PR DESCRIPTION
```c
proc vec3(x: int, y: int, z: int) => {int; int; int} {
    var v : #ret_type = {x, y, z};

    return v;
}

// Will not compile: #ret_type (without arg) must be used inside a procedure.
//var inv : #ret_type = 10;

proc main() => int {
    var v : #ret_type(vec3) = vec3(1, 2, 3); // Equivalent to var v := vec3(1,2,3);
    #static_assert(#typeid(#typeof(v)) == #typeid({int; int; int;}));

    // Will not compile: variable `not_a_proc` is not a procedure.
    //var not_a_proc : int = 2;
    //var v2 : #ret_type(not_a_proc) = 10;

    // 1 + 2 + 3 = 6
    return v.[0] + v.[1] + v.[2];
}
```