### PR TITLE
Add a unique bool type (true (1), false (0))

### DIFF
--- a/src/ast.c
+++ b/src/ast.c
@@ -303,6 +303,21 @@ Expr* new_expr_compound_lit(Allocator* allocator, TypeSpec* typespec, size_t num
     return (Expr*)expr;
 }
 
+Expr* new_expr_bool_lit(Allocator* allocator, bool val, ProgRange range)
+{
+    ExprBoolLit* expr = new_expr(allocator, ExprBoolLit, range);
+    expr->val = val;
+
+    return (Expr*)expr;
+}
+
+Expr* new_expr_null_lit(Allocator* allocator, ProgRange range)
+{
+    ExprNullLit* expr = new_expr(allocator, ExprNullLit, range);
+
+    return (Expr*)expr;
+}
+
 DeclAnnotation* new_annotation(Allocator* allocator, Identifier* ident, ProgRange range)
 {
     DeclAnnotation* annotation = alloc_type(allocator, DeclAnnotation, true);
@@ -2081,6 +2096,15 @@ char* ftprint_expr(Allocator* allocator, Expr* expr)
             }
 
             ftprint_char_array(&dstr, false, "})");
+        } break;
+        case CST_ExprBoolLit: {
+            ExprBoolLit* e = (ExprBoolLit*)expr;
+            dstr = array_create(allocator, char, 16);
+            ftprint_char_array(&dstr, false, "%s", e->val ? "true" : "false");
+        } break;
+        case CST_ExprNullLit: {
+            dstr = array_create(allocator, char, 6);
+            ftprint_char_array(&dstr, false, "null");
         } break;
         default: {
             ftprint_err("Unknown expr kind: %d\n", expr->kind);

--- a/src/ast.h
+++ b/src/ast.h
@@ -816,6 +816,7 @@ extern int type_integer_ranks[];
 void init_builtin_types(OS target_os, Arch target_arch, Allocator* ast_mem, TypeCache* type_cache);
 const char* type_name(Type* type);
 bool type_is_integer_like(Type* type);
+bool type_is_bool(Type* type);
 bool type_is_signed(Type* type);
 bool type_is_arithmetic(Type* type);
 bool type_is_scalar(Type* type);

--- a/src/ast.h
+++ b/src/ast.h
@@ -169,6 +169,8 @@ typedef enum ExprKind {
     CST_ExprIndexof,
     CST_ExprLength,
     CST_ExprCompoundLit,
+    CST_ExprBoolLit,
+    CST_ExprNullLit,
 } ExprKind;
 
 struct Expr {
@@ -319,6 +321,15 @@ typedef struct ExprCompoundLit {
     List initzers;
 } ExprCompoundLit;
 
+typedef struct ExprBoolLit {
+    Expr super;
+    bool val;
+} ExprBoolLit;
+
+typedef struct ExprNullLit {
+    Expr super;
+} ExprNullLit;
+
 Expr* new_expr_ternary(Allocator* allocator, Expr* cond, Expr* then_expr, Expr* else_expr);
 Expr* new_expr_binary(Allocator* allocator, TokenKind op, Expr* left, Expr* right);
 Expr* new_expr_unary(Allocator* allocator, TokenKind op, Expr* expr, ProgRange range);
@@ -339,6 +350,8 @@ Expr* new_expr_indexof(Allocator* allocator, TypeSpec* obj_ts, Identifier* field
 Expr* new_expr_length(Allocator* allocator, Expr* arg, ProgRange range);
 MemberInitializer* new_member_initializer(Allocator* allocator, Expr* init, Designator designator, ProgRange range);
 Expr* new_expr_compound_lit(Allocator* allocator, TypeSpec* type, size_t num_initzers, List* initzers, ProgRange range);
+Expr* new_expr_bool_lit(Allocator* allocator, bool val, ProgRange range);
+Expr* new_expr_null_lit(Allocator* allocator, ProgRange range);
 
 char* ftprint_expr(Allocator* allocator, Expr* expr);
 /////////////////////////////

--- a/src/bytecode/procs.c
+++ b/src/bytecode/procs.c
@@ -1261,10 +1261,8 @@ static BBlock* IR_emit_short_circuit_cmp(IR_ProcBuilder* builder, BBlock* bblock
 {
     //
     // NOTE: This procedure will create a deferred comparison containing an array of short-circuit jumps and one final
-    // jump. If the left and right subexpressions are themselves deferred comparisons, then they will be merged into
-    // this parent expression's deferred comparison. Otherwise, subexpressions that are not deferred comparisons will be
-    // compared to zero and converted to either a short-circuit jump (left subexpression) or a final jump (right
-    // subexpression).
+    // jump. The left and right subexpressions are themselves deferred comparisons, and will be merged into
+    // this parent expression's deferred comparison.
     //
 
     dst_op->kind = IR_OPERAND_DEFERRED_CMP;
@@ -1273,24 +1271,13 @@ static BBlock* IR_emit_short_circuit_cmp(IR_ProcBuilder* builder, BBlock* bblock
     IR_Operand left_op = {0};
     IR_Operand right_op = {0};
 
-    bool short_circuit_val;
-    ConditionKind short_circuit_cond;
-
-    if (expr->op == TKN_LOGIC_AND) {
-        short_circuit_val = false;
-        short_circuit_cond = COND_EQ;
-    }
-    else {
-        assert(expr->op == TKN_LOGIC_OR);
-        short_circuit_val = true;
-        short_circuit_cond = COND_NEQ;
-    }
+    bool short_circuit_val = (expr->op == TKN_LOGIC_OR);
 
     // Emit instructions for the left expression.
     BBlock* left_end_bb = IR_emit_expr(builder, bblock, expr->left, &left_op, tmp_obj_list);
     BBlock* right_bb;
 
-    // If the left subexpression is a deferred comparison, merge into this deferred comparison result.
+    // Merge the left sub-expression into this deferred comparison result.
     //
     // Short-circuit jumps from the left subexpression with the same "short-circuit value" are kept as-is.
     //
@@ -1300,85 +1287,49 @@ static BBlock* IR_emit_short_circuit_cmp(IR_ProcBuilder* builder, BBlock* bblock
     //
     // The left subexpression's final jump is added as a short-circuit jump.
     //
-    // LEFT OFF HERE!!!! nocheckin
-    // TODO: BOTH operands of && and || are now bools! So they will always be DEFERRED_CMP!!!!!!!!!!
-    if (left_op.kind == IR_OPERAND_DEFERRED_CMP) {
-        // Copy list of short-circuit jumps.
-        dst_op->cmp.first_sc_jmp = left_op.cmp.first_sc_jmp;
-        dst_op->cmp.last_sc_jmp = left_op.cmp.last_sc_jmp;
+    assert(left_op.kind == IR_OPERAND_DEFERRED_CMP);
 
-        // Convert left expression's final jmp to a short-circuit jmp.
-        IR_DeferredJmpcc j;
+    // Copy list of short-circuit jumps.
+    dst_op->cmp.first_sc_jmp = left_op.cmp.first_sc_jmp;
+    dst_op->cmp.last_sc_jmp = left_op.cmp.last_sc_jmp;
 
-        right_bb = IR_copy_sc_jmp(builder, left_end_bb, &j, &left_op.cmp.final_jmp, short_circuit_val);
-        IR_new_deferred_sc_jmp(builder, &dst_op->cmp, j.cmp, j.result, j.jmp);
+    // Convert left expression's final jmp to a short-circuit jmp.
+    IR_DeferredJmpcc j;
 
-        // Patch and remove short-circuit jumps with the opposite "short-circuit value".
-        IR_DeferredJmpcc* it = dst_op->cmp.first_sc_jmp;
-        IR_DeferredJmpcc* prev_it = NULL;
+    right_bb = IR_copy_sc_jmp(builder, left_end_bb, &j, &left_op.cmp.final_jmp, short_circuit_val);
+    IR_new_deferred_sc_jmp(builder, &dst_op->cmp, j.cmp, j.result, j.jmp);
 
-        while (it) {
-            IR_DeferredJmpcc* next_it = it->next;
+    // Patch and remove short-circuit jumps with the opposite "short-circuit value".
+    IR_DeferredJmpcc* it = dst_op->cmp.first_sc_jmp;
+    IR_DeferredJmpcc* prev_it = NULL;
 
-            if (it->result != short_circuit_val) {
-                IR_patch_jmp_target(it->jmp, right_bb);
-                IR_del_deferred_sc_jmp(builder, &dst_op->cmp, prev_it, it);
-            }
+    while (it) {
+        IR_DeferredJmpcc* next_it = it->next;
 
-            it = next_it;
-            prev_it = it;
+        if (it->result != short_circuit_val) {
+            IR_patch_jmp_target(it->jmp, right_bb);
+            IR_del_deferred_sc_jmp(builder, &dst_op->cmp, prev_it, it);
         }
-    }
 
-    // The left subexpression is some computation (not a deferred comparison). Compare the left subexpression to zero
-    // and create a short-circuit jmp.
-    else {
-        left_end_bb = IR_op_to_r(builder, left_end_bb, &left_op);
-
-        IR_Reg imm_reg = IR_next_reg(builder);
-        IR_emit_instr_limm(builder, left_end_bb, left_op.type, imm_reg, ir_zero_imm);
-
-        IR_Reg cmp_reg = IR_next_reg(builder);
-        Instr* cmp_instr = IR_emit_instr_cmp(builder, left_end_bb, left_op.type, short_circuit_cond, cmp_reg, left_op.reg, imm_reg);
-
-        right_bb = IR_alloc_bblock(builder);
-        Instr* jmp_instr = IR_emit_instr_cond_jmp(builder, left_end_bb, NULL, right_bb, cmp_reg);
-
-        IR_new_deferred_sc_jmp(builder, &dst_op->cmp, cmp_instr, short_circuit_val, jmp_instr);
+        it = next_it;
+        prev_it = it;
     }
 
     // Emit instructions for the right expression.
     BBlock* right_end_bb = IR_emit_expr(builder, right_bb, expr->right, &right_op, tmp_obj_list);
     BBlock* last_bb;
 
-    // If the right subexpression is a deferred comparison, merge into this deferred comparison result.
+    // Merge the right sub-expression into this deferred comparison result.
+    //
     // The right subexpression's short-circuit jumps are kept as-is.
     // The right subexpression's final jump is converted to a final jump to the "false" control path.
-    if (right_op.kind == IR_OPERAND_DEFERRED_CMP) {
-        // Merge lists of short-circuit jumps.
-        IR_mov_deferred_sc_jmp_list(&dst_op->cmp, &right_op.cmp);
+    assert(right_op.kind == IR_OPERAND_DEFERRED_CMP);
 
-        // Convert the right expression's final jmp into a final jmp to the "false" path.
-        last_bb = IR_copy_sc_jmp(builder, right_end_bb, &dst_op->cmp.final_jmp, &right_op.cmp.final_jmp, false);
-    }
-    // The right subexpression is some computation (not a deferred comparison). Compare the right subexpression to zero
-    // and create a final jump.
-    else {
-        right_end_bb = IR_op_to_r(builder, right_end_bb, &right_op);
+    // Merge lists of short-circuit jumps.
+    IR_mov_deferred_sc_jmp_list(&dst_op->cmp, &right_op.cmp);
 
-        IR_Reg imm_reg = IR_next_reg(builder);
-        IR_emit_instr_limm(builder, right_end_bb, right_op.type, imm_reg, ir_zero_imm);
-
-        IR_Reg cmp_reg = IR_next_reg(builder);
-        Instr* cmp_instr = IR_emit_instr_cmp(builder, right_end_bb, right_op.type, COND_EQ, cmp_reg, right_op.reg, imm_reg);
-
-        last_bb = IR_alloc_bblock(builder);
-        Instr* jmp_instr = IR_emit_instr_cond_jmp(builder, right_end_bb, NULL, last_bb, cmp_reg);
-
-        dst_op->cmp.final_jmp.result = false;
-        dst_op->cmp.final_jmp.jmp = jmp_instr;
-        dst_op->cmp.final_jmp.cmp = cmp_instr;
-    }
+    // Convert the right expression's final jmp into a final jmp to the "false" path.
+    last_bb = IR_copy_sc_jmp(builder, right_end_bb, &dst_op->cmp.final_jmp, &right_op.cmp.final_jmp, false);
 
     return last_bb;
 }

--- a/src/bytecode/procs.c
+++ b/src/bytecode/procs.c
@@ -1299,6 +1299,9 @@ static BBlock* IR_emit_short_circuit_cmp(IR_ProcBuilder* builder, BBlock* bblock
     // with the opposite "short-circuit value" are compared to the right subexpression.
     //
     // The left subexpression's final jump is added as a short-circuit jump.
+    //
+    // LEFT OFF HERE!!!! nocheckin
+    // TODO: BOTH operands of && and || are now bools! So they will always be DEFERRED_CMP!!!!!!!!!!
     if (left_op.kind == IR_OPERAND_DEFERRED_CMP) {
         // Copy list of short-circuit jumps.
         dst_op->cmp.first_sc_jmp = left_op.cmp.first_sc_jmp;

--- a/src/nibble.c
+++ b/src/nibble.c
@@ -418,6 +418,9 @@ static bool init_keywords()
         [KW_SWITCH] = string_view_lit("switch"),
         [KW_CASE] = string_view_lit("case"),
         [KW_UNDERSCORE] = string_view_lit("_"),
+        [KW_TRUE] = string_view_lit("true"),
+        [KW_FALSE] = string_view_lit("false"),
+        [KW_NULL] = string_view_lit("null")
     };
 
     for (int i = 0; i < KW_COUNT; i += 1) {

--- a/src/nibble.h
+++ b/src/nibble.h
@@ -157,6 +157,10 @@ typedef enum Keyword {
     KW_CASE,
     KW_UNDERSCORE,
 
+    KW_TRUE,
+    KW_FALSE,
+    KW_NULL,
+
     KW_COUNT,
 } Keyword;
 

--- a/src/nibble.h
+++ b/src/nibble.h
@@ -80,6 +80,7 @@ typedef struct Float {
 } Float;
 
 typedef enum IntegerKind {
+    INTEGER_BOOL,
     INTEGER_U8,
     INTEGER_S8,
     INTEGER_U16,
@@ -92,6 +93,7 @@ typedef enum IntegerKind {
 
 typedef struct Integer {
     union {
+        bool _bool;
         u8 _u8;
         s8 _s8;
         u16 _u16;

--- a/src/parser.c
+++ b/src/parser.c
@@ -977,6 +977,9 @@ static Expr* parse_expr_ident(Parser* parser)
 // expr_base = TKN_INT
 //           | TKN_FLOAT
 //           | TKN_STR
+//           | KW_TRUE
+//           | KW_FALSE
+//           | KW_NULL
 //           | expr_ident
 //           | expr_compound_init
 //           | expr_sizeof
@@ -1018,6 +1021,15 @@ static Expr* parse_expr_base(Parser* parser)
         return parse_expr_compound_lit(parser);
     case TKN_KW: {
         switch (token.as_kw.ident->kw) {
+        case KW_TRUE:
+            next_token(parser);
+            return new_expr_bool_lit(parser->ast_arena, true, token.range);
+        case KW_FALSE:
+            next_token(parser);
+            return new_expr_bool_lit(parser->ast_arena, false, token.range);
+        case KW_NULL:
+            next_token(parser);
+            return new_expr_null_lit(parser->ast_arena, token.range);
         case KW_SIZEOF:
             return parse_expr_sizeof(parser);
         case KW_TYPEID:

--- a/tests/bool.nib
+++ b/tests/bool.nib
@@ -1,0 +1,30 @@
+proc foo(a : int) => int {
+    if (a) {
+        return 10;
+    }
+    else {
+        return 3;
+    }
+}
+
+proc main() => int {
+    const b1 : bool = 15; // Casting an integer to bool reduces range to false (0) or true (1)
+    #static_assert(b1 == 1);
+
+    const b2 : bool = 0;
+    #static_assert(b2 == 0);
+
+    var num : int = 11;
+    var b3 : bool = num;
+
+    var b4 : bool = -1; // If integer != 0, the bool is true (1).
+
+    var ptr : ^int = ^num;
+    var b5 : bool = ptr; // Non-null pointer is true (1).
+
+    var null_ptr : ^int = 0;
+    var b6 : bool = null_ptr; // Null pointer is false (0).
+
+    // 1 + 0 + 1 + 1 + 1 + 0 + 10 - 3 = 11
+    return b1 + b2 + b3 + b4 + b5 + b6 + foo(5) - foo(0);
+}

--- a/tests/bool.nib
+++ b/tests/bool.nib
@@ -10,9 +10,11 @@ proc foo(a : int) => int {
 proc main() => int {
     const b1 : bool = 15; // Casting an integer to bool reduces range to false (0) or true (1)
     #static_assert(b1 == 1);
+    #static_assert(b1 == true);
 
     const b2 : bool = 0;
     #static_assert(b2 == 0);
+    #static_assert(b2 == false);
 
     var num : int = 11;
     var b3 : bool = num;
@@ -22,9 +24,14 @@ proc main() => int {
     var ptr : ^int = ^num;
     var b5 : bool = ptr; // Non-null pointer is true (1).
 
-    var null_ptr : ^int = 0;
+    var null_ptr : ^int = null;
     var b6 : bool = null_ptr; // Null pointer is false (0).
 
-    // 1 + 0 + 1 + 1 + 1 + 0 + 10 - 3 = 11
-    return b1 + b2 + b3 + b4 + b5 + b6 + foo(5) - foo(0);
+    var x : int;
+    if (num == true) { // 11 is true
+        x = 2;
+    }
+
+    // 1 + 0 + 1 + 1 + 1 + 0 + 10 - 3 (1 + 0) + 2 = 14
+    return b1 + b2 + b3 + b4 + b5 + b6 + foo(5) - foo(0) + (true + false) + x;
 }

--- a/tests/bool.nib
+++ b/tests/bool.nib
@@ -27,11 +27,6 @@ proc main() => int {
     var null_ptr : ^int = null;
     var b6 : bool = null_ptr; // Null pointer is false (0).
 
-    var x : int;
-    if (num == true) { // 11 is true
-        x = 2;
-    }
-
-    // 1 + 0 + 1 + 1 + 1 + 0 + 10 - 3 (1 + 0) + 2 = 14
-    return b1 + b2 + b3 + b4 + b5 + b6 + foo(5) - foo(0) + (true + false) + x;
+    // 1 + 0 + 1 + 1 + 1 + 0 + 10 - 3 + (1 + 0) = 12
+    return b1 + b2 + b3 + b4 + b5 + b6 + foo(5) - foo(0) + (true + false) ;
 }


### PR DESCRIPTION
Previously, `bool` was just an alias of `u8`. This PR makes bool a unique type.

### Implicit conversion from integer to bool
All integer types can be implicitly converted to a boolean value. An integer value of 0 converts to a boolean value of `false`. Alternatively, any **non-zero** integer value converts to a boolean value of `true`.

### Implicit conversion from pointer to bool
All pointer values can be implicitly converted to a boolean value. This is primarily used to check if a pointer is valid (i.e., not null). A `null` pointer value converts to a boolean value of `false`. Otherwise, a valid pointer value converts to a boolean value of `true`.

### Implicit conversion from bool to any integer
A bool can only represent the values `true` or `false`. A boolean value of `true` converts to an integer value of 1. A boolean value of `false` converts an integer value of 0.

### Test program

```c
proc foo(a : int) => int {
    if (a) {
        return 10;
    }
    else {
        return 3;
    }
}

proc main() => int {
    const b1 : bool = 15; // Casting an integer to bool reduces range to false (0) or true (1)
    #static_assert(b1 == 1);
    #static_assert(b1 == true);

    const b2 : bool = 0;
    #static_assert(b2 == 0);
    #static_assert(b2 == false);

    var num : int = 11;
    var b3 : bool = num;

    var b4 : bool = -1; // If integer != 0, the bool is true (1).

    var ptr : ^int = ^num;
    var b5 : bool = ptr; // Non-null pointer is true (1).

    var null_ptr : ^int = null;
    var b6 : bool = null_ptr; // Null pointer is false (0).

    // 1 + 0 + 1 + 1 + 1 + 0 + 10 - 3 + (1 + 0) = 12
    return b1 + b2 + b3 + b4 + b5 + b6 + foo(5) - foo(0) + (true + false) ;
}
```